### PR TITLE
KRACOEUS-8761

### DIFF
--- a/coeus-impl/src/main/java/org/kuali/kra/award/home/AwardServiceImpl.java
+++ b/coeus-impl/src/main/java/org/kuali/kra/award/home/AwardServiceImpl.java
@@ -116,7 +116,7 @@ public class AwardServiceImpl implements AwardService {
             Map<String, CustomAttributeDocument> customAttributeDocuments = oldAward.getAwardDocument().getCustomAttributeDocuments();
             for (Map.Entry<String, CustomAttributeDocument> entry : customAttributeDocuments.entrySet()) {
                 CustomAttributeDocument customAttributeDocument = entry.getValue();
-                if(!availableCustomAttributes.contains(customAttributeDocument.getId())) {
+                if(!availableCustomAttributes.contains(customAttributeDocument.getId().intValue())) {
                     AwardCustomData awardCustomData = new AwardCustomData();
                     awardCustomData.setCustomAttributeId((long) customAttributeDocument.getId());
                     awardCustomData.setCustomAttribute(customAttributeDocument.getCustomAttribute());

--- a/coeus-impl/src/main/java/org/kuali/kra/institutionalproposal/service/impl/InstitutionalProposalServiceImpl.java
+++ b/coeus-impl/src/main/java/org/kuali/kra/institutionalproposal/service/impl/InstitutionalProposalServiceImpl.java
@@ -673,7 +673,7 @@ public class InstitutionalProposalServiceImpl implements InstitutionalProposalSe
             Map<String, CustomAttributeDocument> customAttributeDocuments = oldInstitutionalProposal.getInstitutionalProposalDocument().getCustomAttributeDocuments();
             for (Map.Entry<String, CustomAttributeDocument> entry : customAttributeDocuments.entrySet()) {
                 CustomAttributeDocument customAttributeDocument = entry.getValue();
-                if(!availableCustomAttributes.contains(customAttributeDocument.getId())) {
+                if(!availableCustomAttributes.contains(customAttributeDocument.getId().intValue())) {
                     InstitutionalProposalCustomData customData = new InstitutionalProposalCustomData();
                     customData.setCustomAttributeId((long) customAttributeDocument.getId());
                     customData.setCustomAttribute(customAttributeDocument.getCustomAttribute());

--- a/coeus-impl/src/main/resources/repository.xml
+++ b/coeus-impl/src/main/resources/repository.xml
@@ -439,9 +439,6 @@
 		<reference-descriptor name="unit" class-ref="org.kuali.coeus.common.framework.unit.Unit" auto-retrieve="true" auto-update="none" auto-delete="none">
         	<foreignkey field-ref="ownedByUnit" />
     	</reference-descriptor>
-        <reference-descriptor name="organizations" class-ref="org.kuali.coeus.common.framework.org.Organization" auto-retrieve="true" auto-update="none" auto-delete="none">
-            <foreignkey field-ref="organization" />
-        </reference-descriptor>
 		<reference-descriptor name="sponsor" class-ref="org.kuali.coeus.common.framework.sponsor.Sponsor" auto-retrieve="true" auto-update="none" auto-delete="none">
         	<foreignkey field-ref="sponsorCode" />
     	</reference-descriptor>


### PR DESCRIPTION
KRACOEUS-8761
Custom data fields erased when editing Institutional Proposals or Awards
Also removed an incorrect mapping for NonOrganizationalRolodex in repository xml.
This reference Organizations is only mapped in repository and not defined in rolodex bo.
Also looking at the table, organization name is persisted in organization column not organization id.
We just need to refer to organization for organization name and owned by unit for organization id.

Above mapping was causing issue while adding sponsor template and editing a final version.
Testing award, looks good now.
