### PR TITLE
KRACOEUS-8854 : Fix issue with bad data so script can apply

### DIFF
--- a/coeus-db/coeus-db-sql/src/main/resources/co/kuali/coeus/data/migration/sql/mysql/kc/bootstrap/V600_046__KC_TBL_AWARD_BUDGET_EXT.sql
+++ b/coeus-db/coeus-db-sql/src/main/resources/co/kuali/coeus/data/migration/sql/mysql/kc/bootstrap/V600_046__KC_TBL_AWARD_BUDGET_EXT.sql
@@ -25,6 +25,16 @@ alter table AWARD_BUDGET_EXT add AWARD_ID decimal(22,0)
 update AWARD_BUDGET_EXT budget set AWARD_ID = (select award.AWARD_ID from AWARD award left join BUDGET_DOCUMENT budgetdoc on award.document_number = budgetdoc.parent_document_key where budget.DOCUMENT_NUMBER = budgetdoc.DOCUMENT_NUMBER)
 /
 
+-- in the case an award could not be found, which indicates the award was deleted, save invalid records into orphan table and then delete them
+create table AWARD_BUDGET_EXT_ORPHAN like AWARD_BUDGET_EXT
+/
+
+insert into AWARD_BUDGET_EXT_ORPHAN select * from AWARD_BUDGET_EXT where AWARD_ID is null
+/
+
+delete from AWARD_BUDGET_EXT where AWARD_ID is null
+/
+
 alter table AWARD_BUDGET_EXT modify AWARD_ID decimal(22,0) not null
 /
 


### PR DESCRIPTION
Current data in customer database prevents not null constraint from applying. This appears to be due to inconsistent data as a related Award cannot be found based on document linkages. Likely the associated award was deleted through manual means, but award budget was not. Given that this is customer data though, I'd rather ignore the bad data and be able to upgrade the database vs having to clean the database before upgrading.

Luckily right now as we don't have any customer data actually upgraded and running on 6.x code we can still make changes to these scripts, but in the future this will become impossible. We will need to be careful and ensure that scripts all apply before prod or pre-prod databases have scripts applied. Hopefully CD infra will help with this.

Before merging this though, please make sure myself or someone else is capable of re-initializing any existing 6.0 envs as once this is merged any previously upgraded database will cause KC to not start.