### PR TITLE
KRACOEUS-8824 : Fix duplicate current KualiDocument

### DIFF
--- a/coeus-db/coeus-db-sql/src/main/resources/co/kuali/coeus/data/migration/sql/mysql/rice/bootstrap/V601_010__Fix_Duplicate_KEW_Docs.sql
+++ b/coeus-db/coeus-db-sql/src/main/resources/co/kuali/coeus/data/migration/sql/mysql/rice/bootstrap/V601_010__Fix_Duplicate_KEW_Docs.sql
@@ -1,0 +1,1 @@
+update KREW_DOC_TYP_T set cur_ind = 0 where doc_typ_id = 2680;


### PR DESCRIPTION
Bootstrap sql scripts create 2 duplicate and "current" versions of KualiDocument in KREW_DOC_TYP_T. This sets the original hard-coded ID to not be current. You can see the original insert in V300_011__KREW_DOC_TYP_T.sql and the second in V300_078__KR_05_KREW_DOC_TYP_T.sql. Both are bootstrap scripts so all KC databases should have at least these 2.