### PR TITLE
Set default.htm as an index file so help works when null

### DIFF
--- a/coeus-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/coeus-webapp/src/main/webapp/WEB-INF/web.xml
@@ -460,6 +460,7 @@
     <welcome-file-list>
         <welcome-file>index.html</welcome-file>
         <welcome-file>index.jsp</welcome-file>
+        <welcome-file>default.htm</welcome-file>
     </welcome-file-list>
 
     <!-- only need to include this for the kuali tlds


### PR DESCRIPTION
Even when the help url is null, in the case of a missing help parameter
the help index will still show up. Partial fix for rSmart/issues#512