### PR TITLE
KRACOEUS-8855:Make PD KEW doc standalone and repackage KEW related class

### DIFF
--- a/coeus-db/coeus-db-sql/src/main/resources/co/kuali/coeus/data/migration/sql/mysql/rice/bootstrap/V601_015__KRACOEUS-8855.sql
+++ b/coeus-db/coeus-db-sql/src/main/resources/co/kuali/coeus/data/migration/sql/mysql/rice/bootstrap/V601_015__KRACOEUS-8855.sql
@@ -1,0 +1,1 @@
+update KREW_RULE_ATTR_T set cls_nm = 'org.kuali.coeus.sys.impl.workflow.CopyCustomActionListAttribute' where cls_nm = 'org.kuali.kra.workflow.CopyCustomActionListAttribute';

--- a/coeus-db/coeus-db-xml/src/main/resources/org/kuali/coeus/coeus-xml/2/ProposalDevelopmentDocument.xml
+++ b/coeus-db/coeus-db-xml/src/main/resources/org/kuali/coeus/coeus-xml/2/ProposalDevelopmentDocument.xml
@@ -151,6 +151,10 @@
       <name>CollegeRouting</name>
       <description>College Routing</description>
     </ruleTemplate>
+    <ruleTemplate allowOverwrite="true">
+		<name>HierarchyParentDispositionApproval</name>
+		<description>Approval rule from the hierarchy parent to hierarchy children.</description>
+	</ruleTemplate>
   </ruleTemplates>
   <rules xmlns="ns:workflow/Rule" xsi:schemaLocation="ns:workflow/Rule resource:Rule">
 
@@ -183,4 +187,155 @@
     </rule>
 
   </rules>
+  
+	<ruleAttributes xmlns="ns:workflow/RuleAttribute" xsi:schemaLocation="ns:workflow/RuleAttribute resource:RuleAttribute">
+		<ruleAttribute>
+			<name>CopyCustomActionListAttribute</name>
+			<className>
+				org.kuali.coeus.sys.impl.workflow.CopyCustomActionListAttribute
+			</className>
+			<label>Copy Action List Attribute</label>
+			<description>Copy Action List Attribute</description>
+			<type>ActionListAttribute</type>
+			<serviceNamespace>KC</serviceNamespace>
+		</ruleAttribute>
+
+		<ruleAttribute>
+			<name>AggregatorSearchAttribute</name>
+			<className>org.kuali.rice.kew.docsearch.xml.StandardGenericXMLSearchableAttribute</className>
+			<label>AggregatorSearchAttribute</label>
+			<description>AggregatorSearchAttribute</description>
+			<type>SearchableXmlAttribute</type>
+			<serviceNamespace>KC</serviceNamespace>
+			<searchingConfig>
+				<fieldDef name="aggregator" title="Aggregator">
+					<display>
+						<type>text</type>
+					</display>
+					<lookup businessObjectClass="org.kuali.rice.kim.api.identity.Person">
+				      <fieldConversions>
+				        <fieldConversion lookupFieldName="principalName" localFieldName="aggregator"/>
+				      </fieldConversions>
+				    </lookup>
+					
+					<fieldEvaluation>
+						<!-- not sure yet -->
+						<!--  example //organization/organizationId -->
+						<xpathexpression>
+							//aggregator/string
+						</xpathexpression>
+					</fieldEvaluation>
+				</fieldDef>
+				<xmlSearchContent>
+					<users>
+						<aggregator>
+							<value>%aggregator%</value>
+						</aggregator>
+					</users>
+				</xmlSearchContent>
+			</searchingConfig>
+		</ruleAttribute>
+		<ruleAttribute>
+			<name>BudgetCreatorSearchAttribute</name>
+			<className>
+				org.kuali.rice.kew.docsearch.xml.StandardGenericXMLSearchableAttribute
+			</className>
+			<label>BudgetCreatorSearchAttribute</label>
+			<description>BudgetCreatorSearchAttribute</description>
+			<type>SearchableXmlAttribute</type>
+			<serviceNamespace>KC</serviceNamespace>
+			<searchingConfig>
+				<fieldDef name="budgetCreator" title="Budget Creator">
+					<display>
+						<type>text</type>
+					</display>
+					<lookup businessObjectClass="org.kuali.rice.kim.api.identity.Person">
+				      <fieldConversions>
+				        <fieldConversion lookupFieldName="principalName" localFieldName="budgetCreator"/>
+				      </fieldConversions>
+				    </lookup>
+					
+					<fieldEvaluation>
+						<xpathexpression>
+							//budgetcreator/string
+						</xpathexpression>
+					</fieldEvaluation>
+				</fieldDef>
+				<xmlSearchContent>
+					<users>
+						<budgetCreator>
+							<value>%budgetCreator%</value>
+						</budgetCreator>
+					</users>
+				</xmlSearchContent>
+			</searchingConfig>
+		</ruleAttribute>
+		<ruleAttribute>
+			<name>NarrativeWriterSearchAttribute</name>
+			<className>org.kuali.rice.kew.docsearch.xml.StandardGenericXMLSearchableAttribute</className>
+			<label>NarrativeWriterSearchAttribute</label>
+			<description>NarrativeWriterSearchAttribute</description>
+			<type>SearchableXmlAttribute</type>
+			<serviceNamespace>KC</serviceNamespace>
+			<searchingConfig>
+				<fieldDef name="narrativeWriter"
+					title="Narrative Writer">
+					<display>
+						<type>text</type>
+					</display>
+					<lookup businessObjectClass="org.kuali.rice.kim.api.identity.Person">
+				      <fieldConversions>
+				        <fieldConversion lookupFieldName="principalName" localFieldName="narrativeWriter"/>
+				      </fieldConversions>
+				    </lookup>
+					
+					<fieldEvaluation>
+						<xpathexpression>
+							//narrativewriter/string
+						</xpathexpression>
+					</fieldEvaluation>
+				</fieldDef>
+				<xmlSearchContent>
+					<users>
+						<narrativeWriter>
+							<value>%narrativeWriter%</value>
+						</narrativeWriter>
+					</users>
+				</xmlSearchContent>
+			</searchingConfig>
+		</ruleAttribute>
+		<ruleAttribute>
+			<name>ViewerSearchAttribute</name>
+			<className>org.kuali.rice.kew.docsearch.xml.StandardGenericXMLSearchableAttribute</className>
+			<label>ViewerSearchAttribute</label>
+			<description>ViewerSearchAttribute</description>
+			<type>SearchableXmlAttribute</type>
+			<serviceNamespace>KC</serviceNamespace>
+			<searchingConfig>
+				<fieldDef name="viewer" title="Viewer">
+					<display>
+						<type>text</type>
+					</display>
+					<lookup businessObjectClass="org.kuali.rice.kim.api.identity.Person">
+				      <fieldConversions>
+				        <fieldConversion lookupFieldName="principalName" localFieldName="viewer"/>
+				      </fieldConversions>
+				    </lookup>
+					
+					<fieldEvaluation>
+						<xpathexpression>
+							//viewer/string
+						</xpathexpression>
+					</fieldEvaluation>
+				</fieldDef>
+				<xmlSearchContent>
+					<users>
+						<viewer>
+							<value>%viewer%</value>
+						</viewer>
+					</users>
+				</xmlSearchContent>
+			</searchingConfig>
+		</ruleAttribute>
+	</ruleAttributes>  
 </data>

--- a/coeus-impl/src/main/java/org/kuali/coeus/sys/impl/workflow/CopyCustomActionListAttribute.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/sys/impl/workflow/CopyCustomActionListAttribute.java
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.kuali.kra.workflow;
+package org.kuali.coeus.sys.impl.workflow;
 
 import org.kuali.rice.kew.actionlist.CustomActionListAttribute;
 import org.kuali.rice.kew.api.action.ActionItem;


### PR DESCRIPTION
The PD KEW File that was being used by CX was apparently dependent on the previous foundation KEW file being ingested first. I have copied relevant elements from it such that this file can be ingested into an empty database.