### PR TITLE
KRACOEUS-8809 Refresh budget summary during sync

### DIFF
--- a/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/budget/hierarchy/ProposalBudgetHierarchyController.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/budget/hierarchy/ProposalBudgetHierarchyController.java
@@ -56,7 +56,9 @@ public class ProposalBudgetHierarchyController extends ProposalBudgetControllerB
             displayMessage(ProposalHierarchyKeyConstants.MESSAGE_SYNC_SUCCESS);
             ((ProposalBudgetViewHelperServiceImpl)form.getViewHelperService()).prepareHierarchySummary(form);
         }
-        return save(form);
+        saveBudget(form);
+        checkAudit(form);
+        return getModelAndViewService().getModelAndView(form);
     }
 
     @Transactional @RequestMapping(value = "/proposalBudget", params = "methodToCall=syncBudget")
@@ -70,7 +72,9 @@ public class ProposalBudgetHierarchyController extends ProposalBudgetControllerB
             displayMessage(ProposalHierarchyKeyConstants.MESSAGE_SYNC_SUCCESS);
             ((ProposalBudgetViewHelperServiceImpl)form.getViewHelperService()).prepareHierarchySummary(form);
         }
-        return save(form);
+        saveBudget(form);
+        checkAudit(form);
+        return getModelAndViewService().getModelAndView(form);
     }
 
     @Transactional @RequestMapping(value = "/proposalBudget", params={"methodToCall=navigate", "actionParameters[navigateToPageId]=PropBudget-HierarchySummaryPage"})


### PR DESCRIPTION
Budget summary is not updated while performing sync operation in parent
proposal budget.
We need to persist (similar to proposal) updated budget information via sync operation.
Also navigation was not working when budget is opened in view mode.
Fixing navigation as part of this JIRA
