### PR TITLE
KRACOEUS-8883:implement widget input only for questions with lookups

### DIFF
--- a/coeus-impl/src/main/java/org/kuali/kra/web/krad/QuestionField.java
+++ b/coeus-impl/src/main/java/org/kuali/kra/web/krad/QuestionField.java
@@ -68,6 +68,9 @@ public class QuestionField extends InputFieldBase {
             valuesFinder.setAddBlankOption(false);
             setOptionsFinder(valuesFinder);
         } else if (StringUtils.isNotBlank(answer.getQuestion().getLookupClass())) {
+            ((TextControlBase) getControl()).setMaxLength(null);
+            this.getControl().getAdditionalCssClasses().add("questionnaire-widgetInputOnly");
+            this.setOnDocumentReadyScript("Kc.Questionnaire.Answer.setWidgetInputOnly()");
             if (useSuggest) {
                 getSuggest().setRender(true);
                 getSuggest().setValuePropertyName(answer.getQuestion().getLookupReturn());

--- a/coeus-webapp/src/main/webapp/scripts/common/questionnaire.js
+++ b/coeus-webapp/src/main/webapp/scripts/common/questionnaire.js
@@ -176,4 +176,7 @@ Kc.Questionnaire.Answer = Kc.Questionnaire.Answer || {};
 		 return (condition == 11 && (date1 < date2)) ||
 		            (condition == 12 && (date1 > date2));
 	 };
+    namespace.setWidgetInputOnly = function() {
+        $('.questionnaire-widgetInputOnly').each(function() {$(this).attr('readOnly',true)});
+    }
 })(Kc.Questionnaire.Answer, jQuery);


### PR DESCRIPTION
The krad widgetInputOnly property doesn't work if there is a quickfinder on the input field.   Implemented my own version of widgetInputOnly.