### PR TITLE
KRACOEUS-8803 Fix unauthorized lead unit options

### DIFF
--- a/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/core/ProposalDevelopmentServiceImpl.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/core/ProposalDevelopmentServiceImpl.java
@@ -772,11 +772,15 @@ public class ProposalDevelopmentServiceImpl implements ProposalDevelopmentServic
 
         List<Map<String,String>> qualifiers = roleService.getNestedRoleQualifiersForPrincipalByRoleIds(userId, roleIds, qualification);
         for (Map<String,String> qualifier : qualifiers) {
-            Unit unit = getUnitService().getUnit(qualifier.get(KcKimAttributes.UNIT_NUMBER));
-            if (unit != null) {
-                units.add(unit);
-                if (qualifier.containsKey(KcKimAttributes.SUBUNITS) && StringUtils.equalsIgnoreCase("Y", qualifier.get(KcKimAttributes.SUBUNITS))) {
-                    addDescendantUnits(unit, units);
+        	String unitNumber = qualifier.get(KcKimAttributes.UNIT_NUMBER);
+        	boolean userHasPermission = unitAuthorizationService.hasPermission(userId, unitNumber, namespaceCode, permissionName);
+            if(userHasPermission) {
+            	Unit unit = getUnitService().getUnit(unitNumber);
+                if (unit != null) {
+                    units.add(unit);
+                    if (qualifier.containsKey(KcKimAttributes.SUBUNITS) && StringUtils.equalsIgnoreCase("Y", qualifier.get(KcKimAttributes.SUBUNITS))) {
+                        addDescendantUnits(unit, units, userId, namespaceCode, permissionName);
+                    }
                 }
             }
         }
@@ -789,13 +793,16 @@ public class ProposalDevelopmentServiceImpl implements ProposalDevelopmentServic
                 ParameterConstants.DOCUMENT_COMPONENT, KeyConstants.AUTOGENERATE_INSTITUTIONAL_PROPOSAL_PARAM);
     }
     
-    protected void addDescendantUnits(Unit parentUnit, Set<Unit> units) {
+    protected void addDescendantUnits(Unit parentUnit, Set<Unit> units, String userId, String namespaceCode, String permissionName) {
         List<Unit> subunits = getUnitService().getSubUnits(parentUnit.getUnitNumber());
         if (CollectionUtils.isNotEmpty(subunits)) {
-            units.addAll(subunits);
-            for (Unit subunit : subunits) {
-                addDescendantUnits(subunit, units);
-            }
+                for (Unit subunit : subunits) {
+                   	boolean userHasPermission = unitAuthorizationService.hasPermission(userId, subunit.getUnitNumber(), namespaceCode, permissionName);
+                   	if(userHasPermission) {
+                   		units.add(subunit);
+                       	addDescendantUnits(subunit, units, userId, namespaceCode, permissionName);
+                   	}
+                }
         }
     }
     


### PR DESCRIPTION
Creating a new group, adding member and assigning it to a role is adding unauthorized lead unit
options.
KIM is not checking whether user is associated with the new group. We need a rice fix.
@blackcathacker this is an interim solution as discussed with Terry.
I have created a new rice JIRA KULRICE-14194 and added some details.
 