### PR TITLE
KRACOEUS-8176 Save budget to reflect totals in periods and budget

### DIFF
--- a/coeus-impl/src/main/java/org/kuali/coeus/common/budget/impl/personnel/BudgetPersonnelBudgetServiceImpl.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/common/budget/impl/personnel/BudgetPersonnelBudgetServiceImpl.java
@@ -294,7 +294,6 @@ public class BudgetPersonnelBudgetServiceImpl implements BudgetPersonnelBudgetSe
         	addPersonnelToPeriod(budgetPeriod, groupedBudgetLineItem, newBudgetPersonnelDetail);
         	calculateBudgetPersonnelLineItem(budget, groupedBudgetLineItem, newBudgetPersonnelDetail, newLineNumber);
     	}
-    	groupedBudgetLineItem = getDataObjectService().save(groupedBudgetLineItem);
     	if(newLineItem) {
             budgetPeriod.getBudgetLineItems().add(groupedBudgetLineItem);
     	}

--- a/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/budget/nonpersonnel/ProposalBudgetPeriodProjectCostController.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/budget/nonpersonnel/ProposalBudgetPeriodProjectCostController.java
@@ -81,9 +81,9 @@ public class ProposalBudgetPeriodProjectCostController extends ProposalBudgetCon
 		newBudgetLineItem.setBudget(budget);
         getBudgetService().populateNewBudgetLineItem(newBudgetLineItem, currentTabBudgetPeriod);
         getBudgetCalculationService().populateCalculatedAmount(budget, newBudgetLineItem);
-		newBudgetLineItem = getDataObjectService().save(newBudgetLineItem);
         currentTabBudgetPeriod.getBudgetLineItems().add(newBudgetLineItem);            
         getBudgetService().recalculateBudgetPeriod(budget, currentTabBudgetPeriod);
+        getDataObjectService().save(budget);
 		form.getAddProjectBudgetLineItemHelper().reset();
 	    validateBudgetExpenses(budget, currentTabBudgetPeriod);
 		return getModelAndViewService().getModelAndView(form);

--- a/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/budget/person/ProposalBudgetProjectPersonnelController.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/budget/person/ProposalBudgetProjectPersonnelController.java
@@ -240,8 +240,9 @@ public class ProposalBudgetProjectPersonnelController extends ProposalBudgetCont
 		boolean rulePassed = isAddRulePassed(budget, currentTabBudgetPeriod, newBudgetLineItem, newBudgetPersonnelDetail);
 		if(rulePassed) {
 			getBudgetPersonnelBudgetService().addBudgetPersonnelToPeriod(currentTabBudgetPeriod, newBudgetLineItem, newBudgetPersonnelDetail);
-			form.getAddProjectPersonnelHelper().reset();
 		    getBudgetCalculationService().calculateBudgetPeriod(budget, currentTabBudgetPeriod);
+		    getDataObjectService().save(budget);
+			form.getAddProjectPersonnelHelper().reset();
 		}
 		return getModelAndViewService().getModelAndView(form);
 	}


### PR DESCRIPTION
Adding a line item and closing window should recalcuate budget and
persist line item. Persist budget in this scenario since
we need to update periods and totals and budget totals.
Persisting only line item doesn't work as totals in budget and periods page
will not be updated. Also incorrect details will be displayed in PD budget page.
So we need to save budget.
