### PR TITLE
KRACOEUS-8748, KRACOEUS-8930: making global errors visible, adding delete rule

### DIFF
--- a/coeus-impl/src/main/java/org/kuali/coeus/common/impl/custom/attr/CustomAttributeDocumentMaintenanceDocumentRule.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/common/impl/custom/attr/CustomAttributeDocumentMaintenanceDocumentRule.java
@@ -20,16 +20,16 @@ package org.kuali.coeus.common.impl.custom.attr;
 
 import org.kuali.coeus.common.framework.custom.attr.CustomAttribute;
 import org.kuali.coeus.common.framework.custom.attr.CustomAttributeDocument;
+import org.kuali.coeus.sys.framework.rule.KcMaintenanceDocumentRuleBase;
 import org.kuali.kra.infrastructure.Constants;
 import org.kuali.kra.infrastructure.KeyConstants;
 import org.kuali.rice.kns.document.MaintenanceDocument;
-import org.kuali.rice.kns.maintenance.rules.MaintenanceDocumentRuleBase;
 import org.kuali.rice.krad.util.GlobalVariables;
 
 import java.util.HashMap;
 import java.util.Map;
 
-public class CustomAttributeDocumentMaintenanceDocumentRule  extends MaintenanceDocumentRuleBase {
+public class CustomAttributeDocumentMaintenanceDocumentRule  extends KcMaintenanceDocumentRuleBase {
     
 
     public CustomAttributeDocumentMaintenanceDocumentRule() {

--- a/coeus-impl/src/main/java/org/kuali/coeus/common/impl/custom/attr/CustomAttributeMaintenanceDocumentRule.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/common/impl/custom/attr/CustomAttributeMaintenanceDocumentRule.java
@@ -20,13 +20,13 @@ package org.kuali.coeus.common.impl.custom.attr;
 
 import org.apache.commons.lang3.StringUtils;
 import org.kuali.coeus.common.framework.custom.attr.CustomAttribute;
+import org.kuali.coeus.sys.framework.rule.KcMaintenanceDocumentRuleBase;
 import org.kuali.kra.infrastructure.Constants;
 import org.kuali.rice.core.api.util.RiceKeyConstants;
 import org.kuali.rice.kns.document.MaintenanceDocument;
-import org.kuali.rice.kns.maintenance.rules.MaintenanceDocumentRuleBase;
 import org.kuali.rice.krad.util.GlobalVariables;
 
-public class CustomAttributeMaintenanceDocumentRule extends MaintenanceDocumentRuleBase {
+public class CustomAttributeMaintenanceDocumentRule extends KcMaintenanceDocumentRuleBase {
     
 
     public CustomAttributeMaintenanceDocumentRule() {

--- a/coeus-impl/src/main/java/org/kuali/coeus/common/impl/org/OrganizationMaintenanceDocumentRule.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/common/impl/org/OrganizationMaintenanceDocumentRule.java
@@ -22,13 +22,13 @@ import org.apache.commons.lang3.StringUtils;
 import org.kuali.coeus.common.framework.org.Organization;
 import org.kuali.coeus.common.framework.org.OrganizationYnq;
 import org.kuali.coeus.common.api.rolodex.RolodexService;
+import org.kuali.coeus.sys.framework.rule.KcMaintenanceDocumentRuleBase;
 import org.kuali.coeus.sys.framework.service.KcServiceLocator;
 import org.kuali.coeus.sys.framework.validation.ErrorReporter;
 import org.kuali.kra.infrastructure.KeyConstants;
 import org.kuali.rice.kns.document.MaintenanceDocument;
-import org.kuali.rice.kns.maintenance.rules.MaintenanceDocumentRuleBase;
 
-public class OrganizationMaintenanceDocumentRule  extends MaintenanceDocumentRuleBase {
+public class OrganizationMaintenanceDocumentRule  extends KcMaintenanceDocumentRuleBase {
 
 
     public OrganizationMaintenanceDocumentRule() {

--- a/coeus-impl/src/main/java/org/kuali/coeus/common/impl/ynq/YnqMaintenanceDocumentRule.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/common/impl/ynq/YnqMaintenanceDocumentRule.java
@@ -19,13 +19,13 @@
 package org.kuali.coeus.common.impl.ynq;
 
 import org.kuali.coeus.common.framework.ynq.Ynq;
+import org.kuali.coeus.sys.framework.rule.KcMaintenanceDocumentRuleBase;
 import org.kuali.kra.infrastructure.Constants;
 import org.kuali.kra.infrastructure.KeyConstants;
 import org.kuali.rice.kns.document.MaintenanceDocument;
-import org.kuali.rice.kns.maintenance.rules.MaintenanceDocumentRuleBase;
 import org.kuali.rice.krad.util.GlobalVariables;
 
-public class YnqMaintenanceDocumentRule  extends MaintenanceDocumentRuleBase {
+public class YnqMaintenanceDocumentRule  extends KcMaintenanceDocumentRuleBase {
 
 
     public YnqMaintenanceDocumentRule() {

--- a/coeus-impl/src/main/java/org/kuali/coeus/common/questionnaire/impl/core/QuestionnaireMaintenanceDocumentRule.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/common/questionnaire/impl/core/QuestionnaireMaintenanceDocumentRule.java
@@ -24,11 +24,11 @@ import org.kuali.coeus.common.questionnaire.framework.core.QuestionnaireConstant
 import org.kuali.coeus.common.questionnaire.framework.core.QuestionnaireQuestion;
 import org.kuali.coeus.common.questionnaire.framework.core.QuestionnaireService;
 import org.kuali.coeus.common.questionnaire.framework.core.QuestionnaireUsage;
+import org.kuali.coeus.sys.framework.rule.KcMaintenanceDocumentRuleBase;
 import org.kuali.coeus.sys.framework.service.KcServiceLocator;
 import org.kuali.kra.infrastructure.KeyConstants;
 import org.kuali.rice.core.api.util.RiceKeyConstants;
 import org.kuali.rice.kns.document.MaintenanceDocument;
-import org.kuali.rice.kns.maintenance.rules.MaintenanceDocumentRuleBase;
 import org.kuali.rice.krad.service.BusinessObjectService;
 import org.kuali.rice.krad.util.GlobalVariables;
 import org.kuali.rice.krad.util.MessageMap;
@@ -41,7 +41,7 @@ import java.util.Map;
  * 
  * This class is to provide rule validation when questionnaire is to be approved.
  */
-public class QuestionnaireMaintenanceDocumentRule extends MaintenanceDocumentRuleBase {
+public class QuestionnaireMaintenanceDocumentRule extends KcMaintenanceDocumentRuleBase {
     
     public static final String ALREADY_EDITED_ERROR = "error.questionnaire.alreadyEdited";
 

--- a/coeus-impl/src/main/java/org/kuali/coeus/common/questionnaire/impl/question/QuestionMaintenanceDocumentRule.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/common/questionnaire/impl/question/QuestionMaintenanceDocumentRule.java
@@ -24,12 +24,12 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.kuali.coeus.common.framework.custom.attr.CustomAttributeService;
 import org.kuali.coeus.common.questionnaire.framework.question.Question;
+import org.kuali.coeus.sys.framework.rule.KcMaintenanceDocumentRuleBase;
 import org.kuali.coeus.sys.framework.service.KcServiceLocator;
 import org.kuali.kra.infrastructure.Constants;
 import org.kuali.kra.infrastructure.KeyConstants;
 import org.kuali.rice.kns.document.MaintenanceDocument;
 import org.kuali.rice.kns.maintenance.Maintainable;
-import org.kuali.rice.kns.maintenance.rules.MaintenanceDocumentRuleBase;
 import org.kuali.rice.krad.bo.PersistableBusinessObject;
 import org.kuali.rice.krad.exception.ValidationException;
 import org.kuali.rice.krad.util.GlobalVariables;
@@ -39,7 +39,7 @@ import java.util.List;
 /**
  * This class contains the business rules that are specific to Question.
  */
-public class QuestionMaintenanceDocumentRule extends MaintenanceDocumentRuleBase {
+public class QuestionMaintenanceDocumentRule extends KcMaintenanceDocumentRuleBase {
 
     private static final Log LOG = LogFactory.getLog(QuestionMaintenanceDocumentRule.class);
 

--- a/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/editable/BudgetColumnsToAlterMaintenanceDocumentRule.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/editable/BudgetColumnsToAlterMaintenanceDocumentRule.java
@@ -18,17 +18,17 @@
  */
 package org.kuali.coeus.propdev.impl.editable;
 
+import org.kuali.coeus.sys.framework.rule.KcMaintenanceDocumentRuleBase;
 import org.kuali.rice.kns.datadictionary.validation.charlevel.AlphaNumericValidationPattern;
 import org.kuali.rice.kns.datadictionary.validation.charlevel.AlphaValidationPattern;
 import org.kuali.rice.kns.datadictionary.validation.charlevel.AnyCharacterValidationPattern;
 import org.kuali.rice.kns.datadictionary.validation.charlevel.NumericValidationPattern;
 import org.kuali.rice.kns.datadictionary.validation.fieldlevel.DateValidationPattern;
-import org.kuali.rice.kns.maintenance.rules.MaintenanceDocumentRuleBase;
 
 import java.util.HashMap;
 import java.util.Map;
 
-public class BudgetColumnsToAlterMaintenanceDocumentRule extends MaintenanceDocumentRuleBase {
+public class BudgetColumnsToAlterMaintenanceDocumentRule extends KcMaintenanceDocumentRuleBase {
     private static Map<String, String> validationClassesMap = new HashMap<String, String>();
     static {
         validationClassesMap.put(AnyCharacterValidationPattern.class.getName(), "STRING");

--- a/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/editable/PersonEditableFieldRule.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/editable/PersonEditableFieldRule.java
@@ -20,8 +20,8 @@ package org.kuali.coeus.propdev.impl.editable;
 
 import org.apache.commons.lang3.StringUtils;
 import org.kuali.coeus.common.framework.person.attr.PersonEditableField;
+import org.kuali.coeus.sys.framework.rule.KcMaintenanceDocumentRuleBase;
 import org.kuali.rice.kns.document.MaintenanceDocument;
-import org.kuali.rice.kns.maintenance.rules.MaintenanceDocumentRuleBase;
 import org.kuali.rice.krad.service.BusinessObjectService;
 import org.kuali.rice.krad.util.GlobalVariables;
 import org.kuali.rice.krad.util.ObjectUtils;
@@ -37,7 +37,7 @@ import static org.kuali.kra.infrastructure.KeyConstants.ERROR_PERSON_EDITABLE_FI
  * we need to check to see if it already exists or not. If it already exists, don't create a new one. Only change an existing one.
  * 
  */
-public class PersonEditableFieldRule extends MaintenanceDocumentRuleBase {
+public class PersonEditableFieldRule extends KcMaintenanceDocumentRuleBase {
     
         /**
          * Constructs a PersonEditableFieldRule.java.

--- a/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/editable/ProposalColumnsToAlterMaintenanceDocumentRule.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/editable/ProposalColumnsToAlterMaintenanceDocumentRule.java
@@ -21,6 +21,7 @@ package org.kuali.coeus.propdev.impl.editable;
 import org.apache.commons.lang3.StringUtils;
 import org.kuali.coeus.propdev.impl.core.ProposalDevelopmentDocument;
 import org.kuali.coeus.sys.framework.persistence.KcPersistenceStructureService;
+import org.kuali.coeus.sys.framework.rule.KcMaintenanceDocumentRuleBase;
 import org.kuali.coeus.sys.framework.service.KcServiceLocator;
 import org.kuali.kra.infrastructure.Constants;
 import org.kuali.kra.infrastructure.KeyConstants;
@@ -32,7 +33,6 @@ import org.kuali.rice.kns.datadictionary.validation.charlevel.AnyCharacterValida
 import org.kuali.rice.kns.datadictionary.validation.charlevel.NumericValidationPattern;
 import org.kuali.rice.kns.datadictionary.validation.fieldlevel.DateValidationPattern;
 import org.kuali.rice.kns.document.MaintenanceDocument;
-import org.kuali.rice.kns.maintenance.rules.MaintenanceDocumentRuleBase;
 import org.kuali.rice.kns.service.DataDictionaryService;
 import org.kuali.rice.kns.service.KNSServiceLocator;
 import org.kuali.rice.krad.datadictionary.AttributeDefinition;
@@ -43,7 +43,7 @@ import org.kuali.rice.krad.util.GlobalVariables;
 import java.util.HashMap;
 import java.util.Map;
 
-public class ProposalColumnsToAlterMaintenanceDocumentRule extends MaintenanceDocumentRuleBase {
+public class ProposalColumnsToAlterMaintenanceDocumentRule extends KcMaintenanceDocumentRuleBase {
     
     private static Map<String, String> validationClassesMap = new HashMap<String, String>();
     static {

--- a/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/person/creditsplit/InvestigatorCreditTypeRule.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/person/creditsplit/InvestigatorCreditTypeRule.java
@@ -19,8 +19,8 @@
 package org.kuali.coeus.propdev.impl.person.creditsplit;
 
 import org.kuali.coeus.common.framework.type.InvestigatorCreditType;
+import org.kuali.coeus.sys.framework.rule.KcMaintenanceDocumentRuleBase;
 import org.kuali.rice.kns.document.MaintenanceDocument;
-import org.kuali.rice.kns.maintenance.rules.MaintenanceDocumentRuleBase;
 import org.kuali.rice.krad.service.BusinessObjectService;
 import org.kuali.rice.krad.util.GlobalVariables;
 import org.kuali.rice.krad.util.ObjectUtils;
@@ -36,7 +36,7 @@ import static org.kuali.kra.infrastructure.KeyConstants.ERROR_INVESTIGATOR_CREDI
  * 
  * @see org.kuali.coeus.common.framework.type.InvestigatorCreditType
  */
-public class InvestigatorCreditTypeRule extends MaintenanceDocumentRuleBase {
+public class InvestigatorCreditTypeRule extends KcMaintenanceDocumentRuleBase {
 
     public InvestigatorCreditTypeRule() {
         super();

--- a/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/s2s/S2SErrorRule.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/s2s/S2SErrorRule.java
@@ -21,17 +21,17 @@ package org.kuali.coeus.propdev.impl.s2s;
 
 import org.apache.commons.lang3.StringUtils;
 import org.kuali.coeus.sys.framework.gv.GlobalVariableService;
+import org.kuali.coeus.sys.framework.rule.KcMaintenanceDocumentRuleBase;
 import org.kuali.coeus.sys.framework.service.KcServiceLocator;
 import org.kuali.rice.core.api.criteria.QueryByCriteria;
 import org.kuali.rice.kns.document.MaintenanceDocument;
-import org.kuali.rice.kns.maintenance.rules.MaintenanceDocumentRuleBase;
 import org.kuali.rice.krad.data.DataObjectService;
 import org.kuali.rice.krad.util.KRADConstants;
 
 import java.util.Collections;
 import java.util.List;
 
-public class S2SErrorRule extends MaintenanceDocumentRuleBase {
+public class S2SErrorRule extends KcMaintenanceDocumentRuleBase {
 
     private DataObjectService dataObjectService;
     private GlobalVariableService globalVariableService;

--- a/coeus-impl/src/main/java/org/kuali/coeus/sys/framework/persistence/KcPersistenceStructureService.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/sys/framework/persistence/KcPersistenceStructureService.java
@@ -18,9 +18,11 @@
  */
 package org.kuali.coeus.sys.framework.persistence;
 
+import org.kuali.rice.krad.bo.DataObjectRelationship;
 import org.kuali.rice.krad.exception.ClassNotPersistableException;
 import org.kuali.rice.krad.service.PersistenceStructureService;
 
+import java.util.List;
 import java.util.Map;
 
 public interface KcPersistenceStructureService extends PersistenceStructureService {
@@ -28,4 +30,6 @@ public interface KcPersistenceStructureService extends PersistenceStructureServi
     Map<String, String> getPersistableAttributesColumnMap(Class clazz) throws ClassNotPersistableException;
     
     Map<String, String> getDBColumnToObjectAttributeMap(Class clazz) throws ClassNotPersistableException;
+
+    List<DataObjectRelationship> getRelationshipsTo(Class persistableClass);
 }

--- a/coeus-impl/src/main/java/org/kuali/coeus/sys/framework/rule/KcMaintenanceDocumentRuleBase.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/sys/framework/rule/KcMaintenanceDocumentRuleBase.java
@@ -22,11 +22,14 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.Maps;
 import org.apache.commons.beanutils.PropertyUtils;
+import org.kuali.coeus.sys.framework.gv.GlobalVariableService;
 import org.kuali.coeus.sys.framework.persistence.KcPersistenceStructureService;
 import org.kuali.coeus.sys.framework.service.KcServiceLocator;
+import org.kuali.kra.infrastructure.KeyConstants;
 import org.kuali.rice.core.api.criteria.CountFlag;
 import org.kuali.rice.core.api.criteria.QueryByCriteria;
 import org.kuali.rice.core.api.util.RiceKeyConstants;
+import org.kuali.rice.krad.bo.BusinessObject;
 import org.kuali.rice.krad.data.DataObjectService;
 import org.kuali.rice.krad.data.metadata.DataObjectMetadata;
 import org.kuali.rice.krad.data.provider.MetadataProvider;
@@ -37,7 +40,6 @@ import org.kuali.rice.kns.maintenance.rules.MaintenanceDocumentRuleBase;
 import org.kuali.rice.krad.bo.DataObjectRelationship;
 import org.kuali.rice.krad.datadictionary.PrimitiveAttributeDefinition;
 import org.kuali.rice.krad.datadictionary.RelationshipDefinition;
-import org.kuali.rice.krad.util.GlobalVariables;
 import org.kuali.rice.krad.util.KRADConstants;
 
 import java.lang.reflect.InvocationTargetException;
@@ -45,11 +47,10 @@ import java.util.*;
 
 public class KcMaintenanceDocumentRuleBase extends MaintenanceDocumentRuleBase {
 
-    private static final String ERROR_DELETION_BLOCKED = "error.deletion.blocked";
-
     private transient KcPersistenceStructureService kcPersistenceStructureService;
     private transient ProviderRegistry providerRegistry;
     private transient DataObjectService dataObjectService;
+    private transient GlobalVariableService globalVariableService;
 
     @Override
     protected boolean processGlobalRouteDocumentBusinessRules(MaintenanceDocument document) {
@@ -75,7 +76,7 @@ public class KcMaintenanceDocumentRuleBase extends MaintenanceDocumentRuleBase {
                 }
             });
             if (getBoService().countMatching(relationship.getParentClass(), criteria) > 0) {
-                GlobalVariables.getMessageMap().putError(KRADConstants.GLOBAL_ERRORS, ERROR_DELETION_BLOCKED);
+                getGlobalVariableService().getMessageMap().putError(KRADConstants.GLOBAL_ERRORS, KeyConstants.ERROR_DELETION_BLOCKED);
                 return false;
             }
         }
@@ -104,7 +105,7 @@ public class KcMaintenanceDocumentRuleBase extends MaintenanceDocumentRuleBase {
             }
 
             if (getBoService().countMatching(relationship.getSourceClass(), criteria) > 0) {
-                GlobalVariables.getMessageMap().putError(KRADConstants.GLOBAL_ERRORS, ERROR_DELETION_BLOCKED);
+                getGlobalVariableService().getMessageMap().putError(KRADConstants.GLOBAL_ERRORS, KeyConstants.ERROR_DELETION_BLOCKED);
                 return false;
             }
         }
@@ -138,7 +139,7 @@ public class KcMaintenanceDocumentRuleBase extends MaintenanceDocumentRuleBase {
                             .setCountFlag(CountFlag.ONLY)
                             .build())
                     .getTotalRowCount() > 0) {
-                GlobalVariables.getMessageMap().putError(KRADConstants.GLOBAL_ERRORS, ERROR_DELETION_BLOCKED);
+                getGlobalVariableService().getMessageMap().putError(KRADConstants.GLOBAL_ERRORS, KeyConstants.ERROR_DELETION_BLOCKED);
                 return false;
             }
         }
@@ -153,11 +154,11 @@ public class KcMaintenanceDocumentRuleBase extends MaintenanceDocumentRuleBase {
      * 
      * This method to check pk does exist in table.  Maybe this should be in service instead in this rule base
      */
-    protected boolean checkExistenceFromTable(Class clazz, Map fieldValues, String errorField, String errorParam) {
+    protected boolean checkExistenceFromTable(Class<? extends BusinessObject> clazz, Map<String, ?> fieldValues, String errorField, String errorParam) {
         boolean success = true;
         success = getBoService().countMatching(clazz, fieldValues) != 0;
         if (!success) {
-            GlobalVariables.getMessageMap().putErrorWithoutFullErrorPath(KRADConstants.MAINTENANCE_NEW_MAINTAINABLE + errorField, RiceKeyConstants.ERROR_EXISTENCE, errorParam);
+            getGlobalVariableService().getMessageMap().putErrorWithoutFullErrorPath(KRADConstants.MAINTENANCE_NEW_MAINTAINABLE + errorField, RiceKeyConstants.ERROR_EXISTENCE, errorParam);
         }
         return success;
     }
@@ -195,4 +196,14 @@ public class KcMaintenanceDocumentRuleBase extends MaintenanceDocumentRuleBase {
         this.dataObjectService = dataObjectService;
     }
 
+    protected GlobalVariableService getGlobalVariableService() {
+        if (globalVariableService == null) {
+            this.globalVariableService = KcServiceLocator.getService(GlobalVariableService.class);
+        }
+        return globalVariableService;
+    }
+
+    public void setGlobalVariableService(GlobalVariableService globalVariableService) {
+        this.globalVariableService = globalVariableService;
+    }
 }

--- a/coeus-impl/src/main/java/org/kuali/coeus/sys/framework/rule/KcMaintenanceDocumentRuleBase.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/sys/framework/rule/KcMaintenanceDocumentRuleBase.java
@@ -18,29 +18,140 @@
  */
 package org.kuali.coeus.sys.framework.rule;
 
+import com.google.common.base.Predicate;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.Maps;
+import org.apache.commons.beanutils.PropertyUtils;
+import org.kuali.coeus.sys.framework.persistence.KcPersistenceStructureService;
+import org.kuali.coeus.sys.framework.service.KcServiceLocator;
+import org.kuali.rice.core.api.criteria.CountFlag;
+import org.kuali.rice.core.api.criteria.QueryByCriteria;
 import org.kuali.rice.core.api.util.RiceKeyConstants;
+import org.kuali.rice.krad.data.DataObjectService;
+import org.kuali.rice.krad.data.metadata.DataObjectMetadata;
+import org.kuali.rice.krad.data.provider.MetadataProvider;
+import org.kuali.rice.krad.data.provider.ProviderRegistry;
+import org.kuali.rice.krad.datadictionary.BusinessObjectEntry;
+import org.kuali.rice.kns.document.MaintenanceDocument;
 import org.kuali.rice.kns.maintenance.rules.MaintenanceDocumentRuleBase;
+import org.kuali.rice.krad.bo.DataObjectRelationship;
+import org.kuali.rice.krad.datadictionary.PrimitiveAttributeDefinition;
+import org.kuali.rice.krad.datadictionary.RelationshipDefinition;
 import org.kuali.rice.krad.util.GlobalVariables;
 import org.kuali.rice.krad.util.KRADConstants;
 
-import java.util.Map;
+import java.lang.reflect.InvocationTargetException;
+import java.util.*;
 
 public class KcMaintenanceDocumentRuleBase extends MaintenanceDocumentRuleBase {
-    
-    public boolean processRules(KcDocumentEventBaseExtension event) {
-        boolean retVal = false;
-        retVal = event.getRule().processRules(event);
+
+    private static final String ERROR_DELETION_BLOCKED = "error.deletion.blocked";
+
+    private transient KcPersistenceStructureService kcPersistenceStructureService;
+    private transient ProviderRegistry providerRegistry;
+    private transient DataObjectService dataObjectService;
+
+    @Override
+    protected boolean processGlobalRouteDocumentBusinessRules(MaintenanceDocument document) {
+        boolean retVal = super.processGlobalRouteDocumentBusinessRules(document);
+
+        if (document.getNewMaintainableObject().getMaintenanceAction().equals(KRADConstants.MAINTENANCE_DELETE_ACTION)) {
+            retVal &= verifyOjbRelationships() && verifyDDRelationships() && verifyKradDataRelationships();
+        }
         return retVal;
+    }
+
+    protected boolean verifyOjbRelationships() {
+        final List<DataObjectRelationship> ojbRelationships = getKcPersistenceStructureService().getRelationshipsTo(getNewBo().getClass());
+        for (DataObjectRelationship relationship : ojbRelationships) {
+            final Map<String, Object> criteria = Maps.transformEntries(relationship.getParentToChildReferences(), new Maps.EntryTransformer<String, String, Object>() {
+                @Override
+                public Object transformEntry(String key, String value) {
+                    try {
+                        return PropertyUtils.getProperty(getNewBo(), value);
+                    } catch (IllegalAccessException|InvocationTargetException|NoSuchMethodException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            });
+            if (getBoService().countMatching(relationship.getParentClass(), criteria) > 0) {
+                GlobalVariables.getMessageMap().putError(KRADConstants.GLOBAL_ERRORS, ERROR_DELETION_BLOCKED);
+                return false;
+            }
+        }
+        return true;
+    }
+
+    protected boolean verifyDDRelationships() {
+        final Collection<RelationshipDefinition> ddRelationships = new ArrayList<>();
+        for (BusinessObjectEntry entry : getDataDictionaryService().getDataDictionary().getBusinessObjectEntries().values()) {
+            ddRelationships.addAll(Collections2.filter(entry.getRelationships(), new Predicate<RelationshipDefinition>() {
+                @Override
+                public boolean apply(RelationshipDefinition relationship) {
+                    return relationship.getTargetClass().equals(getNewBo().getClass());
+                }
+            }));
+        }
+
+        for (RelationshipDefinition relationship : ddRelationships) {
+            final Map<String, Object> criteria = new HashMap<>();
+            for (PrimitiveAttributeDefinition attr : relationship.getPrimitiveAttributes()) {
+                try {
+                    criteria.put(attr.getSourceName(), PropertyUtils.getProperty(getNewBo(), attr.getTargetName()));
+                } catch (IllegalAccessException|InvocationTargetException|NoSuchMethodException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+
+            if (getBoService().countMatching(relationship.getSourceClass(), criteria) > 0) {
+                GlobalVariables.getMessageMap().putError(KRADConstants.GLOBAL_ERRORS, ERROR_DELETION_BLOCKED);
+                return false;
+            }
+        }
+        return true;
+    }
+
+    protected boolean verifyKradDataRelationships() {
+        final Map<Class<?>, org.kuali.rice.krad.data.metadata.DataObjectRelationship> kradDataRelationships = new HashMap<>();
+        for (MetadataProvider provider : getProviderRegistry().getMetadataProviders()) {
+            for (DataObjectMetadata entry : provider.provideMetadata().values()) {
+                for (org.kuali.rice.krad.data.metadata.DataObjectRelationship relationship : entry.getRelationships()) {
+                    if (relationship.getRelatedType().equals(getNewBo().getClass())) {
+                        kradDataRelationships.put(entry.getType(), relationship);
+                    }
+                }
+            }
+        }
+
+        for (Map.Entry<Class<?>,org.kuali.rice.krad.data.metadata.DataObjectRelationship> relationship : kradDataRelationships.entrySet()) {
+            final Map<String, Object> criteria = new HashMap<>();
+            for (org.kuali.rice.krad.data.metadata.DataObjectAttributeRelationship attr : relationship.getValue().getAttributeRelationships()) {
+                try {
+                    criteria.put(attr.getParentAttributeName(), PropertyUtils.getProperty(getNewBo(), attr.getChildAttributeName()));
+                } catch (IllegalAccessException|InvocationTargetException|NoSuchMethodException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+
+            if (getDataObjectService().findMatching(relationship.getKey(),
+                    QueryByCriteria.Builder.andAttributes(criteria)
+                            .setCountFlag(CountFlag.ONLY)
+                            .build())
+                    .getTotalRowCount() > 0) {
+                GlobalVariables.getMessageMap().putError(KRADConstants.GLOBAL_ERRORS, ERROR_DELETION_BLOCKED);
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public boolean processRules(KcDocumentEventBaseExtension event) {
+        return event.getRule().processRules(event);
     }
     
     /**
      * 
-     * This method to check pk does exist in table.  Maybe this should be in service instead in this rule base ?
-     * @param clazz
-     * @param fieldValues
-     * @param errorField
-     * @param errorParam
-     * @return
+     * This method to check pk does exist in table.  Maybe this should be in service instead in this rule base
      */
     protected boolean checkExistenceFromTable(Class clazz, Map fieldValues, String errorField, String errorParam) {
         boolean success = true;
@@ -49,6 +160,39 @@ public class KcMaintenanceDocumentRuleBase extends MaintenanceDocumentRuleBase {
             GlobalVariables.getMessageMap().putErrorWithoutFullErrorPath(KRADConstants.MAINTENANCE_NEW_MAINTAINABLE + errorField, RiceKeyConstants.ERROR_EXISTENCE, errorParam);
         }
         return success;
+    }
+
+    protected KcPersistenceStructureService getKcPersistenceStructureService() {
+        if (kcPersistenceStructureService == null) {
+            this.kcPersistenceStructureService = KcServiceLocator.getService(KcPersistenceStructureService.class);
+        }
+        return kcPersistenceStructureService;
+    }
+
+    public void setKcPersistenceStructureService(KcPersistenceStructureService kcPersistenceStructureService) {
+        this.kcPersistenceStructureService = kcPersistenceStructureService;
+    }
+
+    protected ProviderRegistry getProviderRegistry() {
+        if (providerRegistry == null) {
+            this.providerRegistry = KcServiceLocator.getService("providerRegistry");
+        }
+        return providerRegistry;
+    }
+
+    public void setProviderRegistry(ProviderRegistry providerRegistry) {
+        this.providerRegistry = providerRegistry;
+    }
+
+    protected DataObjectService getDataObjectService() {
+        if (dataObjectService == null) {
+            this.dataObjectService = KcServiceLocator.getService(DataObjectService.class);
+        }
+        return dataObjectService;
+    }
+
+    public void setDataObjectService(DataObjectService dataObjectService) {
+        this.dataObjectService = dataObjectService;
     }
 
 }

--- a/coeus-impl/src/main/java/org/kuali/kra/infrastructure/KeyConstants.java
+++ b/coeus-impl/src/main/java/org/kuali/kra/infrastructure/KeyConstants.java
@@ -1113,6 +1113,7 @@ public final class KeyConstants {
     public static final String S2S_USER_ATTACHED_FORM_WRONG_FILE_TYPE = "error.s2s.userattachedform.wrong.filetype";
     public static final String S2S_USER_ATTACHED_FORM_NOT_VALID = "error.s2s.userattachedform.invalid";
     public static final String S2S_USER_ATTACHED_FORM_NOT_PDF = "error.s2s.userattachedform.not.pdf";
+    public static final String ERROR_DELETION_BLOCKED = "error.deletion.blocked";
 
     /**
      * private utility class ctor.

--- a/coeus-impl/src/main/java/org/kuali/kra/institutionalproposal/proposallog/ProposalLogMaintenanceDocumentRules.java
+++ b/coeus-impl/src/main/java/org/kuali/kra/institutionalproposal/proposallog/ProposalLogMaintenanceDocumentRules.java
@@ -20,6 +20,7 @@ package org.kuali.kra.institutionalproposal.proposallog;
 
 import org.apache.commons.lang3.StringUtils;
 import org.kuali.coeus.common.api.sponsor.SponsorService;
+import org.kuali.coeus.sys.framework.rule.KcMaintenanceDocumentRuleBase;
 import org.kuali.coeus.sys.framework.service.KcServiceLocator;
 import org.kuali.coeus.sys.framework.util.DateUtils;
 import org.kuali.kra.authorization.KraAuthorizationConstants;
@@ -27,7 +28,6 @@ import org.kuali.kra.infrastructure.Constants;
 import org.kuali.kra.infrastructure.KeyConstants;
 import org.kuali.kra.institutionalproposal.InstitutionalProposalConstants;
 import org.kuali.rice.kns.document.MaintenanceDocument;
-import org.kuali.rice.kns.maintenance.rules.MaintenanceDocumentRuleBase;
 import org.kuali.rice.kns.rules.MaintenanceDocumentRule;
 import org.kuali.rice.krad.util.GlobalVariables;
 import org.kuali.rice.krad.util.ObjectUtils;
@@ -35,7 +35,7 @@ import org.kuali.rice.krad.util.ObjectUtils;
 import java.util.HashMap;
 import java.util.Map;
 
-public class ProposalLogMaintenanceDocumentRules extends MaintenanceDocumentRuleBase
+public class ProposalLogMaintenanceDocumentRules extends KcMaintenanceDocumentRuleBase
     implements MaintenanceDocumentRule {
     
     private final String SPONSOR_CODE = "document.newMaintainableObject.sponsorCode";

--- a/coeus-impl/src/main/resources/ApplicationResources.properties
+++ b/coeus-impl/src/main/resources/ApplicationResources.properties
@@ -1150,3 +1150,9 @@ validationPatternRegex.opportunityId=^[A-Z0-9-]{1,40}$
 validation.fixedPoint=Must be a {0} number, with no more than {1} total digits and {2} digits to the right of the decimal point.
 error.format.org.kuali.rice.kns.datadictionary.validation.fieldlevel.FixedPointValidationPattern=The {0} must be a non-negative number, with no more than {1} total digits and {2} digits to the right of the decimal point.
 error.format.org.kuali.rice.kns.datadictionary.validation.fieldlevel.FixedPointValidationPattern.allowNegative=The {0} must be a number, with no more than {1} total digits and {2} digits to the right of the decimal point.
+
+error.deletion.blocked = This document cannot be Routed because this document deletes a record referenced by other active records.
+
+#add a class so it can be styled with css
+errors.prefix=<div class="kul-error">
+errors.suffix=</div>

--- a/coeus-impl/src/main/resources/org/kuali/coeus/common/impl/rpt/cust/CustReportDetailsMaintenanceDocument.xml
+++ b/coeus-impl/src/main/resources/org/kuali/coeus/common/impl/rpt/cust/CustReportDetailsMaintenanceDocument.xml
@@ -24,7 +24,7 @@
 	<bean id="CustReportDetailsMaintenanceDocument" parent="CustReportDetailsMaintenanceDocument-parentBean" />
 
 	<bean id="CustReportDetailsMaintenanceDocument-parentBean"
-		abstract="true" parent="MaintenanceDocumentEntry">
+		abstract="true" parent="KcMaintenanceDocumentEntry">
 		<property name="businessObjectClass" value="org.kuali.coeus.common.impl.rpt.cust.CustReportDetails" />
 		<property name="maintainableClass"
 			value="org.kuali.kra.maintenance.KraMaintainableImpl" />

--- a/coeus-impl/src/main/resources/org/kuali/coeus/common/impl/rpt/cust/CustReportTypeMaintenanceDocument.xml
+++ b/coeus-impl/src/main/resources/org/kuali/coeus/common/impl/rpt/cust/CustReportTypeMaintenanceDocument.xml
@@ -24,7 +24,7 @@
 	<bean id="CustReportTypeMaintenanceDocument" parent="CustReportTypeMaintenanceDocument-parentBean" />
 
 	<bean id="CustReportTypeMaintenanceDocument-parentBean" abstract="true"
-		parent="MaintenanceDocumentEntry">
+		parent="KcMaintenanceDocumentEntry">
 		<property name="businessObjectClass" value="org.kuali.coeus.common.impl.rpt.cust.CustReportType" />
 		<property name="maintainableClass"
 			value="org.kuali.kra.maintenance.KraMaintainableImpl" />

--- a/coeus-impl/src/main/resources/org/kuali/coeus/common/impl/rpt/cust/CustRptDefaultParmsMaintenanceDocument.xml
+++ b/coeus-impl/src/main/resources/org/kuali/coeus/common/impl/rpt/cust/CustRptDefaultParmsMaintenanceDocument.xml
@@ -24,7 +24,7 @@
 	<bean id="CustRptDefaultParmsMaintenanceDocument" parent="CustRptDefaultParmsMaintenanceDocument-parentBean" />
 
 	<bean id="CustRptDefaultParmsMaintenanceDocument-parentBean"
-		abstract="true" parent="MaintenanceDocumentEntry">
+		abstract="true" parent="KcMaintenanceDocumentEntry">
 		<property name="businessObjectClass"
 			value="org.kuali.coeus.common.impl.rpt.cust.CustRptDefaultParms" />
 		<property name="maintainableClass"

--- a/coeus-impl/src/main/resources/org/kuali/coeus/common/impl/rpt/cust/CustRptTypeDocumentMaintenanceDocument.xml
+++ b/coeus-impl/src/main/resources/org/kuali/coeus/common/impl/rpt/cust/CustRptTypeDocumentMaintenanceDocument.xml
@@ -24,7 +24,7 @@
 	<bean id="CustRptTypeDocumentMaintenanceDocument" parent="CustRptTypeDocumentMaintenanceDocument-parentBean" />
 
 	<bean id="CustRptTypeDocumentMaintenanceDocument-parentBean"
-		abstract="true" parent="MaintenanceDocumentEntry">
+		abstract="true" parent="KcMaintenanceDocumentEntry">
 		<property name="businessObjectClass"
 			value="org.kuali.coeus.common.impl.rpt.cust.CustRptTypeDocument" />
 		<property name="maintainableClass"

--- a/coeus-impl/src/main/resources/org/kuali/coeus/common/questionnaire/impl/core/QuestionnaireMaintenanceDocument.xml
+++ b/coeus-impl/src/main/resources/org/kuali/coeus/common/questionnaire/impl/core/QuestionnaireMaintenanceDocument.xml
@@ -19,7 +19,7 @@
  -->
 
     <bean id="QuestionnaireMaintenanceDocument" parent="QuestionnaireMaintenanceDocument-parentBean" />
-    <bean id="QuestionnaireMaintenanceDocument-parentBean" abstract="true" parent="MaintenanceDocumentEntry">
+    <bean id="QuestionnaireMaintenanceDocument-parentBean" abstract="true" parent="KcMaintenanceDocumentEntry">
         <property name="businessObjectClass" value="org.kuali.coeus.common.questionnaire.framework.core.Questionnaire" />
         <property name="maintainableClass" value="org.kuali.kra.maintenance.KraMaintainableImpl" />
         <property name="lockingKeys" >

--- a/coeus-impl/src/main/resources/org/kuali/kra/datadictionary/docs/KcMaintenanceDocumentEntry.xml
+++ b/coeus-impl/src/main/resources/org/kuali/kra/datadictionary/docs/KcMaintenanceDocumentEntry.xml
@@ -24,7 +24,8 @@
 
 	<bean id="KcMaintenanceDocumentEntry" parent="KcMaintenanceDocumentEntry-parentBean" />
 	<bean id="KcMaintenanceDocumentEntry-parentBean" abstract="true" parent="MaintenanceDocumentEntry">
-		<property name="workflowProperties">
+        <property name="businessRulesClass" value="org.kuali.coeus.sys.framework.rule.KcMaintenanceDocumentRuleBase"/>
+        <property name="workflowProperties">
 			<ref bean="KcMaintenanceDocument-workflowProperties"/>
 		</property>
 	</bean>

--- a/coeus-webapp/pom.xml
+++ b/coeus-webapp/pom.xml
@@ -70,7 +70,8 @@
             WEB-INF/tags/rice-portal/portalBody.tag,
             WEB-INF/tags/rice-portal/portalTabs.tag,
             kr/WEB-INF/jsp/KualiLookup.jsp,
-            kr/WEB-INF/jsp/KualiMultipleValueLookup.jsp
+            kr/WEB-INF/jsp/KualiMultipleValueLookup.jsp,
+            WEB-INF/tags/kr/page.tag
         </rice.web.excludes>
 
         <rice.output.dir>${project.build.directory}/rice-server</rice.output.dir>

--- a/coeus-webapp/src/main/webapp/WEB-INF/tags/kr/page.tag
+++ b/coeus-webapp/src/main/webapp/WEB-INF/tags/kr/page.tag
@@ -1,0 +1,443 @@
+<%--
+  ~ Copyright 2006-2011 The Kuali Foundation
+  ~
+  ~ Licensed under the Educational Community License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.opensource.org/licenses/ecl2.php
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  --%>
+<%@ include file="/kr/WEB-INF/jsp/tldHeader.jsp"%>
+
+<%@ attribute name="docTitle" required="true" description="The title to display for the page." %>
+<%@ attribute name="transactionalDocument" required="true" description="The name of the document type this document page is rendering." %>
+<%@ attribute name="showDocumentInfo" required="false" description="Boolean value of whether to display the Document Type name and document type help on the page." %>
+<%@ attribute name="headerMenuBar" required="false" description="HTML text for menu bar to display at the top of the page." %>
+<%@ attribute name="headerTitle" required="false" description="The title of this page which will be displayed in the browser's header bar.  If left blank, docTitle will be used instead." %>
+<%@ attribute name="htmlFormAction" required="false" description="The URL that the HTML form rendered on this page will be posted to." %>
+<%@ attribute name="renderMultipart" required="false" description="Boolean value of whether the HTML form rendred on this page will be encoded to accept multipart - ie, uploaded attachment - input." %>
+<%@ attribute name="showTabButtons" required="false" description="Whether to show the show/hide all tabs buttons." %>
+<%@ attribute name="extraTopButtons" required="false" type="java.util.List" description="A List of org.kuali.rice.kns.web.ui.ExtraButton objects to display at the top of the page." %>
+<%@ attribute name="headerDispatch" required="false" description="Overrides the header navigation tab buttons to go directly to the action given here." %>
+<%@ attribute name="lookup" required="false"
+	description="indicates whether the lookup page specific page should be shown"%>
+
+<%-- for non-lookup pages --%>
+<%@ attribute name="headerTabActive" required="false" description="The name of the active header tab, if header navigation is used." %>
+<%@ attribute name="feedbackKey" required="false"
+	description="application resources key that contains feedback contact address only used when lookup attribute is false"%>
+<%@ attribute name="defaultMethodToCall" required="false" description="The name of default methodToCall on the action for this page." %>
+<%@ attribute name="errorKey" required="false" description="If present, this is the key which will be used to match errors that need to be rendered at the top of the page." %>
+<%@ attribute name="auditCount" required="false" description="The number of audit errors displayed on this page." %>
+<%@ attribute name="additionalScriptFiles" required="false"
+	type="java.util.List" description="A List of JavaScript file names to have included on the page." %>
+<%@ attribute name="documentWebScope" required="false" description="The scope this page - which is hard coded to session, making this attribute somewhat useless." %>
+<%@ attribute name="maintenanceDocument" required="false" description="Boolean value of whether this page is rendering a maintenance document." %>
+<%@ attribute name="sessionDocument" required="false" description="Unused." %>
+<%@ attribute name="renderRequiredFieldsLabel" required = "false" description="Boolean value of whether to include a helpful note that the asterisk represents a required field - good for accessibility." %>
+<%@ attribute name="alternativeHelp" required="false"%>
+
+<%-- Is the screen an inquiry? --%>
+<c:set var="_isInquiry"
+	value="${requestScope[Constants.PARAM_MAINTENANCE_VIEW_MODE] eq Constants.PARAM_MAINTENANCE_VIEW_MODE_INQUIRY}" />
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html:html>
+
+<c:if test="${empty headerTitle}">
+	<c:set var="headerTitle" value="${docTitle}"/>
+</c:if>
+
+<head>
+	<meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+<c:if test="${not empty SESSION_TIMEOUT_WARNING_MILLISECONDS}">
+	<script type="text/javascript">
+	<!--
+	setTimeout("alert('Your session will expire in ${SESSION_TIMEOUT_WARNING_MINUTES} minutes.')",'${SESSION_TIMEOUT_WARNING_MILLISECONDS}');
+	// -->
+	</script>
+</c:if>
+
+	<script type="text/javascript">var jsContextPath = "${pageContext.request.contextPath}";</script>
+	<title><bean:message key="app.title" /> :: ${headerTitle}</title>
+	<c:forEach items="${fn:split(ConfigProperties.kns.css.files, ',')}"
+		var="cssFile">
+<c:if test="${fn:length(fn:trim(cssFile)) > 0}">
+			<link href="${pageContext.request.contextPath}/${cssFile}"
+				rel="stylesheet" type="text/css" />
+</c:if>
+</c:forEach>
+	<c:forEach items="${fn:split(ConfigProperties.kns.javascript.files, ',')}"
+		var="javascriptFile">
+<c:if test="${fn:length(fn:trim(javascriptFile)) > 0}">
+			<script language="JavaScript" type="text/javascript"
+				src="${pageContext.request.contextPath}/${javascriptFile}"></script>
+</c:if>
+</c:forEach>
+
+<!-- new iframe resize logic -->
+<script type="text/javascript">
+
+var jq = jQuery.noConflict();
+var bodyHeight;
+function publishHeight(){
+    var parentUrl = "";
+    if(navigator.cookieEnabled){
+        parentUrl = jQuery.cookie('parentUrl');
+        var passedUrl = decodeURIComponent( document.location.hash.replace( /^#/, '' ) );
+        if(passedUrl && passedUrl.substring(0, 4) === "http"){
+            jQuery.cookie('parentUrl', passedUrl, {path: '/'});
+            parentUrl = passedUrl;
+        }
+    }
+
+    if(parentUrl === ""){
+        //make the assumption for not cross-domain, will have no effect if cross domain (message wont be
+        //received)
+        parentUrl = window.location;
+        parentUrl = decodeURIComponent(parentUrl);
+    }
+
+    var height = jQuery("body").outerHeight();
+    jQuery("body").attr("style", "overflow-x: auto; padding-right: 20px;");
+    if (parentUrl && !isNaN(height) && height > 0) {
+        jQuery.postMessage({ if_height: height}, parentUrl, parent);
+        bodyHeight = height;
+    }
+}
+
+jQuery(function(){
+  publishHeight();
+  window.onresize = publishHeight;
+  window.setInterval(publishHeight, 249);
+});
+</script>
+
+    <c:choose>
+    <c:when test="${lookup}" >
+      <c:if test="${not empty KualiForm.headerNavigationTabs}">
+        <link href="kr/css/${KualiForm.navigationCss}" rel="stylesheet" type="text/css" />
+      </c:if>
+
+      <!-- allow for custom lookup calls -->
+      <script language="JavaScript" type="text/javascript" src="${pageContext.request.contextPath}/kr/scripts/lookup.js"></script>
+
+    </c:when>
+    <c:otherwise>
+      <c:forEach items="${additionalScriptFiles}" var="scriptFile" >
+        <script language="JavaScript" type="text/javascript" src="${scriptFile}"></script>
+      </c:forEach>
+    </c:otherwise>
+  </c:choose>
+</head>
+<%--KULRICE-12287:Added a new tag for displaying a banner in the testing environments which
+  * reminds users that it is a non-production environment
+  --%>
+<kul:testBanner />
+<c:choose>
+	<c:when test="${lookup}" >
+		<body onload="placeFocus();
+		<c:if test='<%= jspContext.findAttribute("KualiForm") != null %>'>
+			<c:if test='<%= jspContext.findAttribute("KualiForm").getClass() == org.kuali.rice.kns.web.struts.form.LookupForm.class %>'>
+				<c:out value ="${KualiForm.lookupable.extraOnLoad}" />
+			</c:if>
+		</c:if>
+		">
+    <div id="Uif-Application">
+    <%--KULRICE-12287:* Modified where the backdoor information is displayed on each page
+		  * so it will be included in the header bar instead of being
+		  * absolutely positioned
+		  --%>
+		<c:if
+				test="${! empty headerMenuBar and !_isInquiry and KualiForm.showMaintenanceLinks}">
+				<div class="lookupcreatenew">
+					${headerMenuBar}
+				</div>
+		</c:if>
+		<c:choose>
+			<c:when test="${!empty alternativeHelp}">
+				<h1>${docTitle}<kul:help documentTypeName="${KualiForm.docTypeName}" alternativeHelp="${alternativeHelp}" altText="document help"/></h1>
+			</c:when>
+			<c:otherwise>
+				<c:if test="${showDocumentInfo}">
+					<h1>${docTitle}<kul:help documentTypeName="${KualiForm.docTypeName}" altText="document help"/></h1>
+				</c:if>
+			</c:otherwise>
+		</c:choose>
+
+    </c:when>
+	<c:otherwise>
+		<c:if test="${not empty KualiForm.anchor}">
+			<c:if test="${ConfigProperties.test.mode ne 'true'}">
+				<c:set var="anchorScript"
+					value="jumpToAnchor('${KualiForm.anchor}');" />
+			</c:if>
+		</c:if>
+		<c:if test="${empty anchorScript}">
+		  <c:set var="anchorScript" value="placeFocus();" />
+		</c:if>
+		<body onload="if ( !restoreScrollPosition() ) { ${anchorScript} }"
+			onKeyPress="return isReturnKeyAllowed('${Constants.DISPATCH_REQUEST_PARAMETER}.' , event);">
+    <div id="Uif-Application">
+			<%--KULRICE-12287:Modified where the backdoor information is displayed on each page
+		  * so it will be included in the header bar instead of being
+		  * absolutely positioned
+		  --%>
+			${headerMenuBar}
+	</c:otherwise>
+</c:choose>
+
+<c:set var="encoding" value=""/>
+<c:if test="${not empty renderMultipart and renderMultipart eq true}">
+	<c:set var="encoding" value="multipart/form-data"/>
+</c:if>
+
+<html:form styleId="kualiForm" action="/${htmlFormAction}.do"
+	method="post" enctype="${encoding}" acceptCharset="utf-8"
+	onsubmit="return hasFormAlreadyBeenSubmitted();">
+<c:choose>
+	<c:when test="${lookup}" >
+	</c:when>
+	<c:otherwise>
+		<a name="topOfForm"></a>
+		<div class="headerarea" id="headerarea">
+				<h1>
+					${docTitle}&nbsp;
+					<c:choose>
+						<c:when test="${!empty alternativeHelp}">
+							<kul:help documentTypeName="${KualiForm.docTypeName}" alternativeHelp="${alternativeHelp}" altText="document help" />
+						</c:when>
+						<c:otherwise>
+							<c:if test="${showDocumentInfo}">
+								<kul:help documentTypeName="${KualiForm.docTypeName}" altText="document help"/>
+							</c:if>
+						</c:otherwise>
+					</c:choose>
+				</h1>
+			<c:if test="${!empty defaultMethodToCall}">
+				<kul:enterKey methodToCall="${defaultMethodToCall}" />
+			</c:if>
+    <%--KULRICE-12287: Modified where the backdoor information is displayed on each page
+		      * so it will be included in the header bar instead of being
+		      * absolutely positioned
+		      --%>
+    <kul:backdoor />
+	</c:otherwise>
+</c:choose>
+
+<!-- DOCUMENT INFO HEADER BOX -->
+	<c:set var="docHeaderAttributes"
+		value="${DataDictionary.DocumentHeader.attributes}" />
+<c:if test="${showDocumentInfo}">
+	<c:set var="KualiForm" value="${KualiForm}" />
+	<jsp:useBean id="KualiForm" type="org.kuali.rice.kns.web.struts.form.KualiForm" />
+
+    <c:set var="numberOfHeaderRows" value="<%=new Integer((int) java.lang.Math.ceil((double) KualiForm.getDocInfo().size()/KualiForm.getNumColumns()))%>" />
+    <c:set var="headerFieldCount" value="<%=new Integer(KualiForm.getDocInfo().size())%>" />
+  	<c:set var="headerFields" value="${KualiForm.docInfo}" />
+  	<c:set var="fieldCounter" value="0" />
+
+  <div class="headerbox">
+	<c:choose>
+		<c:when test="${lookup}" >
+					<table summary="document header: general information"
+						cellpadding="0" cellspacing="0">
+		</c:when>
+		<c:otherwise>
+			<table class="headerinfo" summary="document header: general information" cellpadding="0" cellspacing="0">
+		</c:otherwise>
+	</c:choose>
+
+	<c:forEach var="i" begin="1" end="${numberOfHeaderRows}" varStatus="status">
+	 <tr>
+			<c:forEach var="j" begin="1" end="<%=KualiForm.getNumColumns()%>" varStatus="innerStatus">
+				<c:choose>
+					<c:when test="${headerFieldCount > fieldCounter}">
+			 		<c:set var="headerField" value="${headerFields[fieldCounter]}" />
+			 			<c:choose>
+			 				<c:when test="${(empty headerField) or (empty headerField.ddAttributeEntryName)}">
+								<kul:htmlAttributeHeaderCell />
+								<td>&nbsp;</td>
+			 				</c:when>
+			 				<c:otherwise>
+					        	<kul:htmlAttributeHeaderCell attributeEntryName="${headerField.ddAttributeEntryName}" horizontal="true" scope="row" />
+					        	<td>
+					        	<c:if test="${empty headerField.nonLookupValue and empty headerField.displayValue}">
+					        		&nbsp;
+					        	</c:if>
+								<c:choose>
+									<c:when test="${headerField.lookupAware and (not lookup)}" >
+										${headerField.nonLookupValue}
+									</c:when>
+									<c:otherwise>
+										${headerField.displayValue}
+									</c:otherwise>
+								</c:choose>
+						 		</td>
+			 				</c:otherwise>
+			 			</c:choose>
+					</c:when>
+					<c:otherwise>
+						<kul:htmlAttributeHeaderCell />
+						<td>&nbsp;</td>
+					</c:otherwise>
+				</c:choose>
+		 		<c:if test="${headerFieldCount > fieldCounter}">
+			 	</c:if>
+				<c:set var="fieldCounter" value="${fieldCounter+1}" />
+		 </c:forEach>
+      </tr>
+    </c:forEach>
+   </table>
+  </div>
+</c:if>
+
+<c:choose>
+	<c:when test="${lookup}" >
+		<%-- Display the expand/collapse buttons for the lookup/inquiry, if specified. --%>
+		<c:if test="${showTabButtons != '' && showTabButtons == true}">
+			<div class="right">
+				<div class="excol">
+					<div class="lookupcreatenew">
+						<html:image property="methodToCall.showAllTabs" src="${ConfigProperties.kr.externalizable.images.url}tinybutton-expandall.gif" title="show all panel content" alt="show all panel content" styleClass="tinybutton" onclick="return expandAllTab();" tabindex="-1" />
+						<html:image property="methodToCall.hideAllTabs" src="${ConfigProperties.kr.externalizable.images.url}tinybutton-collapseall.gif" title="hide all panel content" alt="hide all panel content" styleClass="tinybutton" onclick="return collapseAllTab();" tabindex="-1" />
+					</div>
+				</div>
+			</div>
+		</c:if>
+	</c:when>
+	<c:otherwise>
+
+		</div>
+		<c:if test="${not empty KualiForm.headerNavigationTabs}">
+            <div class="horz-links-bkgrnd" id="horz-links">
+                <div id="tabs">
+                    <dl class="tabul">
+                        <c:choose>
+                            <c:when test="${empty headerDispatch}">
+                                <c:forEach var="headerTab" items="${KualiForm.headerNavigationTabs}" varStatus="status">
+                                    <c:set var="currentTab" value="${headerTabActive eq headerTab.headerTabNavigateTo}" /> <!-- ${headerTab.headerTabNavigateTo}; ${headerTabActive}; ${currentTab} -->
+                                    <c:choose>
+                                        <c:when test="${currentTab}"><dt class="licurrent"></c:when>
+                                        <c:otherwise><dt></c:otherwise>
+                                    </c:choose>
+                                    <span class="tabright ${currentTab ? 'tabcurrent' : ''}">
+                                        <html:submit value="${headerTab.headerTabDisplayName}" property="methodToCall.headerTab.headerDispatch.${headerDispatch}.navigateTo.${headerTab.headerTabNavigateTo}"  alt="${headerTab.headerTabDisplayName}" disabled="true" />
+                                    </span></dt>
+                                </c:forEach>
+                            </c:when>
+                            <c:otherwise>
+                                <c:forEach var="headerTab" items="${KualiForm.headerNavigationTabs}" varStatus="status">
+                                    <c:set var="currentTab" value="${headerTabActive eq headerTab.headerTabNavigateTo}" /> <!-- ${headerTab.headerTabNavigateTo}; ${headerTabActive}; ${currentTab} -->
+                                    <c:choose><c:when test="${currentTab}"><dt class="licurrent"></c:when><c:otherwise><dt></c:otherwise></c:choose>
+                                    <span class="tabright ${currentTab ? 'tabcurrent' : ''}">
+                                        <html:submit value="${headerTab.headerTabDisplayName}" property="methodToCall.headerTab.headerDispatch.${headerDispatch}.navigateTo.${headerTab.headerTabNavigateTo}"  alt="${headerTab.headerTabDisplayName}" disabled="${headerTab.disabled}"  />
+                                    </span></dt>
+                                </c:forEach>
+                            </c:otherwise>
+                        </c:choose>
+                    </dl>
+                </div>
+            </div>
+        </c:if>
+		<div class="msg-excol">
+		  <div class="left-errmsg">
+			 <kul:errorCount auditCount="${auditCount}"/>
+			 <c:if test="${!empty errorKey}">
+				  <kul:errors keyMatch="${errorKey}" errorTitle="Page Errors:"/>
+			 </c:if>
+			 <c:if test="${empty errorKey}">
+												<kul:errors keyMatch="${Constants.GLOBAL_ERRORS}"
+													errorTitle="Page Errors:" />
+			 </c:if>
+			 <kul:messages/>
+			 <kul:lockMessages/>
+		  </div>
+		  <div class="right">
+		    <div class="excol">
+		  	   <c:if test="${!empty extraTopButtons}">
+		         <c:forEach items="${extraTopButtons}" var="extraButton">
+		           <html:image src="${extraButton.extraButtonSource}" styleClass="tinybutton" property="${extraButton.extraButtonProperty}" alt="${extraButton.extraButtonAltText}" onclick="${extraButton.extraButtonOnclick}"/> &nbsp;&nbsp;
+		         </c:forEach>
+	           </c:if>
+			   <c:if test="${showTabButtons != '' && showTabButtons == true}">
+				  <html:image property="methodToCall.showAllTabs" src="${ConfigProperties.kr.externalizable.images.url}tinybutton-expandall.gif" title="show all panel content" alt="show all panel content" styleClass="tinybutton" onclick="javascript: return expandAllTab(document, tabStatesSize); " tabindex="-1" />
+				  <html:image property="methodToCall.hideAllTabs" src="${ConfigProperties.kr.externalizable.images.url}tinybutton-collapseall.gif" title="hide all panel content" alt="hide all panel content" styleClass="tinybutton" onclick="javascript: return collapseAllTab(document, tabStatesSize); " tabindex="-1" />
+		       </c:if>
+			   <c:if test="${renderRequiredFieldsLabel}" >
+				<br>* required field
+			   </c:if>
+		  	 </div>
+		  </div>
+		</div>
+
+        <script type="text/javascript">
+            //if no error exists then render the error as a message
+            jQuery( document ).ready(function() {
+                if(jQuery(".error").length === 0) {
+                    jQuery(".kul-error").addClass("kul-message");
+                }
+            });
+        </script>
+
+		<table class="page-main" width="100%" cellpadding="0" cellspacing="0">
+			<tr>
+											<td width="1%">
+												<img
+													src="${ConfigProperties.kr.externalizable.images.url}pixel_clear.gif"
+													alt="" width="20" height="20" />
+											</td>
+				<td>
+
+	</c:otherwise>
+</c:choose>
+					<jsp:doBody/>
+
+<c:choose>
+	<c:when test="${lookup}" >
+					<kul:footer lookup="true"/>
+					<!-- So that JS expandAllTab / collapseAllTab know the tabStates size. Subtract 1 because currentTabIndex = size + 1. -->
+					<html:hidden property="tabStatesSize" value="${KualiForm.currentTabIndex - 1}" />
+	</c:when>
+	<c:otherwise>
+					<div class="left-errmsg">
+															<kul:errors displayRemaining="true"
+																errorTitle="Other errors:"
+																warningTitle="Other warnings:"
+																infoTitle="Other informational messages:"/>
+					</div>
+					<kul:footer feedbackKey="${feedbackKey}" />
+
+					<!-- So that JS expandAllTab / collapseAllTab know the tabStates size. Subtract 1 because currentTabIndex = size + 1. -->
+														<html:hidden property="tabStatesSize"
+															value="${KualiForm.currentTabIndex - 1}" />
+
+
+					<!-- state maintenance for returning the user to the action list if they started there -->
+														<logic:present name="KualiForm"
+															property="returnToActionList">
+															<html:hidden name="KualiForm"
+																property="returnToActionList" />
+					</logic:present>
+	</c:otherwise>
+</c:choose>
+<c:if test="${transactionalDocument || maintenanceDocument}">
+    <html:hidden property="documentWebScope" value="session"/>
+	<html:hidden property="formKey" value="${KualiForm.formKey}" />
+	<html:hidden property="docFormKey" value="${KualiForm.formKey}" />
+    <html:hidden property="docNum" value="${KualiForm.document.documentNumber}" />
+</c:if>
+<kul:editablePropertiesGuid />
+
+</html:form>
+<div id="formComplete"></div>
+</div>
+</body>
+
+</html:html>

--- a/coeus-webapp/src/main/webapp/WEB-INF/tags/kr/page.tag
+++ b/coeus-webapp/src/main/webapp/WEB-INF/tags/kr/page.tag
@@ -1,18 +1,21 @@
 <%--
-  ~ Copyright 2006-2011 The Kuali Foundation
-  ~
-  ~ Licensed under the Educational Community License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~ http://www.opensource.org/licenses/ecl2.php
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  --%>
+   - Kuali Coeus, a comprehensive research administration system for higher education.
+   -
+   - Copyright 2005-2015 Kuali, Inc.
+   -
+   - This program is free software: you can redistribute it and/or modify
+   - it under the terms of the GNU Affero General Public License as
+   - published by the Free Software Foundation, either version 3 of the
+   - License, or (at your option) any later version.
+   -
+   - This program is distributed in the hope that it will be useful,
+   - but WITHOUT ANY WARRANTY; without even the implied warranty of
+   - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   - GNU Affero General Public License for more details.
+   -
+   - You should have received a copy of the GNU Affero General Public License
+   - along with this program.  If not, see <http://www.gnu.org/licenses/>.
+--%>
 <%@ include file="/kr/WEB-INF/jsp/tldHeader.jsp"%>
 
 <%@ attribute name="docTitle" required="true" description="The title to display for the page." %>
@@ -350,10 +353,12 @@ jQuery(function(){
 		  <div class="left-errmsg">
 			 <kul:errorCount auditCount="${auditCount}"/>
 			 <c:if test="${!empty errorKey}">
+                 <%-- KC customization, added Heading for bootstrap skinning --%>
 				  <kul:errors keyMatch="${errorKey}" errorTitle="Page Errors:"/>
 			 </c:if>
 			 <c:if test="${empty errorKey}">
-												<kul:errors keyMatch="${Constants.GLOBAL_ERRORS}"
+                 <%-- KC customization, added Heading for bootstrap skinning --%>
+                 <kul:errors keyMatch="${Constants.GLOBAL_ERRORS}"
 													errorTitle="Page Errors:" />
 			 </c:if>
 			 <kul:messages/>
@@ -377,6 +382,7 @@ jQuery(function(){
 		  </div>
 		</div>
 
+        <%-- KC customization, switching the error to a message for bootstrap skinning --%>
         <script type="text/javascript">
             //if no error exists then render the error as a message
             jQuery( document ).ready(function() {

--- a/coeus-webapp/src/main/webapp/css/bootstrap/css/bootstrap-skinned.css
+++ b/coeus-webapp/src/main/webapp/css/bootstrap/css/bootstrap-skinned.css
@@ -8395,7 +8395,8 @@ th {
   width: 100%;
   padding-bottom: 12px;
 }
-.msg-excol .left-errmsg div {
+
+.msg-excol .left-errmsg .kul-message {
   padding: 8px 35px 8px 14px;
   margin-bottom: 20px;
   text-shadow: 0 1px 0 rgba(255, 255, 255, 0.5);
@@ -8424,11 +8425,12 @@ th {
   background-color: #f2dede;
   border-color: #eed3d7;
   color: #b94a48;
-  float: left;
+  max-width: 200px;
   margin-left: 20px;
 }
 .msg-excol .left-errmsg .error + div {
-  display: none;
+    margin-left: 20px;
+    float: left;
 }
 .pull-right {
   float: right;


### PR DESCRIPTION
* Adding rule to check if a record can be deleted before submit (supports OJB, JPA, and DD relationships)
* Making all KC maintenance docs inherit from KcMaintenanceDocumentEntry (ensures that all maintenance docs use KcMaintenanceDocumentRuleBase if not specified
* Making all Kc Rules extend from KcMaintenanceDocumentRuleBase
* Fixing bootstrap skinning so that GLOBAL_ERRORS are visible