### PR TITLE
KRACOEUS-8839:Ensure validations don't grab attachments

### DIFF
--- a/coeus-impl/src/main/java/org/kuali/coeus/common/framework/print/KcAttachmentDataSource.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/common/framework/print/KcAttachmentDataSource.java
@@ -24,7 +24,7 @@ import org.kuali.coeus.sys.framework.model.KcPersistableBusinessObjectBase;
 import org.kuali.coeus.sys.framework.service.KcServiceLocator;
 
 import javax.persistence.*;
-import java.lang.ref.SoftReference;
+import java.lang.ref.WeakReference;
 
 /**
  * 
@@ -43,7 +43,7 @@ public abstract class KcAttachmentDataSource extends KcPersistableBusinessObject
     private String fileDataId;
 
     @Transient
-    private transient SoftReference<byte[]> data;
+    private transient WeakReference<byte[]> data;
 
     @Override
     public String getName() {
@@ -71,9 +71,9 @@ public abstract class KcAttachmentDataSource extends KcPersistableBusinessObject
         		return existingData;
         	}
         }
-        //if we didn't have a softreference, grab the data from the db
+        //if we didn't have a weakreference, grab the data from the db
         byte[] newData = getKcAttachmentDao().getData(fileDataId);
-        data = new SoftReference<byte[]>(newData);
+        data = new WeakReference<byte[]>(newData);
         return newData;
     }
 
@@ -95,6 +95,6 @@ public abstract class KcAttachmentDataSource extends KcPersistableBusinessObject
         } else {
             fileDataId = getKcAttachmentDao().saveData(data, fileDataId);
         }
-        this.data = new SoftReference<byte[]>(data);
+        this.data = new WeakReference<byte[]>(data);
     }
 }

--- a/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/attachment/NarrativeAttachment.xml
+++ b/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/attachment/NarrativeAttachment.xml
@@ -34,7 +34,6 @@
         <ref bean="NarrativeAttachment-moduleNumber" />
         <ref bean="NarrativeAttachment-proposalNumber" />
         <ref bean="NarrativeAttachment-name" />
-        <ref bean="NarrativeAttachment-data" />
       </list>
     </property>
   </bean>
@@ -115,24 +114,6 @@
     <property name="description" value="File Name" />
   </bean>
 
-  <bean id="NarrativeAttachment-data" parent="NarrativeAttachment-data-parentBean"/>
-  <bean id="NarrativeAttachment-data-parentBean" abstract="true" parent="AttributeDefinition">
-    <property name="name" value="data" />
-    <property name="forceUppercase" value="false" />
-    <property name="label" value="Attachment File" />
-    <property name="shortLabel" value="Attachment" />
-    <property name="maxLength" value="0" />
-    <property name="required" value="true" />
-    <property name="control" >
-      <bean parent="TextControlDefinition" p:size="0"/>
-    </property>
-    <property name="controlField">
-      <bean p:size="0" parent="Uif-TextControl"/>
-    </property>
-    <property name="summary" value="Narrative Attachment File" />
-    <property name="description" value="Narrative Attachment File" />
-  </bean>
-
 <!-- Business Object Inquiry Definition -->
   <bean id="NarrativeAttachment-inquiryDefinition" parent="NarrativeAttachment-inquiryDefinition-parentBean" />
   <bean id="NarrativeAttachment-InquiryView" parent="NarrativeAttachment-InquiryView-parentBean"/>
@@ -148,7 +129,6 @@
               <bean parent="FieldDefinition" p:attributeName="moduleNumber" p:forceInquiry="true"/>
               <bean parent="FieldDefinition" p:attributeName="proposalNumber" p:forceInquiry="true"/>
               <bean parent="FieldDefinition" p:attributeName="name"/>
-              <bean parent="FieldDefinition" p:attributeName="data"/>
             </list>
           </property>
         </bean>
@@ -169,7 +149,6 @@
               <bean p:propertyName="moduleNumber" parent="Uif-DataField"/>
               <bean p:propertyName="proposalNumber" parent="Uif-DataField"/>
               <bean p:propertyName="name" parent="Uif-DataField"/>
-              <bean p:propertyName="data" parent="Uif-DataField"/>
             </list>
           </property>
         </bean>
@@ -189,7 +168,6 @@
         <bean parent="FieldDefinition" p:attributeName="moduleNumber"/>
         <bean parent="FieldDefinition" p:attributeName="proposalNumber"/>
         <bean parent="FieldDefinition" p:attributeName="name"/>
-        <bean parent="FieldDefinition" p:attributeName="data"/>
       </list>
     </property>
     <property name="resultFields">
@@ -197,7 +175,6 @@
         <bean parent="FieldDefinition" p:attributeName="moduleNumber" p:forceInquiry="true"/>
         <bean parent="FieldDefinition" p:attributeName="proposalNumber" p:forceInquiry="true"/>
         <bean parent="FieldDefinition" p:attributeName="name"/>
-        <bean parent="FieldDefinition" p:attributeName="data"/>
       </list>
     </property>
   </bean>
@@ -210,7 +187,6 @@
         <bean p:propertyName="moduleNumber" parent="Uif-LookupCriteriaInputField"/>
         <bean p:propertyName="proposalNumber" parent="Uif-LookupCriteriaInputField"/>
         <bean p:propertyName="name" parent="Uif-LookupCriteriaInputField"/>
-        <bean p:propertyName="data" parent="Uif-LookupCriteriaInputField"/>
       </list>
     </property>
     <property name="resultFields" >
@@ -218,7 +194,6 @@
         <bean p:propertyName="moduleNumber" parent="Uif-DataField"/>
         <bean p:propertyName="proposalNumber" parent="Uif-DataField"/>
         <bean p:propertyName="name" parent="Uif-DataField"/>
-        <bean p:propertyName="data" parent="Uif-DataField"/>
       </list>
     </property>
   </bean>

--- a/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/person/attachment/ProposalPersonBiographyAttachment.xml
+++ b/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/person/attachment/ProposalPersonBiographyAttachment.xml
@@ -34,7 +34,6 @@
         <ref bean="ProposalPersonBiographyAttachment-proposalPersonNumber" />
         <ref bean="ProposalPersonBiographyAttachment-biographyNumber" />
         <ref bean="ProposalPersonBiographyAttachment-proposalNumber" />
-        <ref bean="ProposalPersonBiographyAttachment-data" />
         <ref bean="ProposalPersonBiographyAttachment-name" />
       </list>
     </property>
@@ -113,23 +112,6 @@
     <property name="description" value="The unique proposal number identifying a proposal. This is a system generated, sequential number." />
   </bean>
 
-  <bean id="ProposalPersonBiographyAttachment-data" parent="ProposalPersonBiographyAttachment-data-parentBean"/>
-  <bean id="ProposalPersonBiographyAttachment-data-parentBean" abstract="true" parent="AttributeDefinition">
-    <property name="name" value="data" />
-    <property name="forceUppercase" value="false" />
-    <property name="label" value="Bio Attachment File" />
-    <property name="shortLabel" value="Bio Attachment File" />
-    <property name="maxLength" value="0" />
-    <property name="control" >
-      <bean parent="TextControlDefinition" p:size="0"/>
-    </property>
-    <property name="controlField">
-      <bean p:size="0" parent="Uif-TextControl"/>
-    </property>
-    <property name="summary" value="Bio Attachment File" />
-    <property name="description" value="Bio Attachment File" />
-  </bean>
-
   <bean id="ProposalPersonBiographyAttachment-name" parent="ProposalPersonBiographyAttachment-name-parentBean"/>
   <bean id="ProposalPersonBiographyAttachment-name-parentBean" abstract="true" parent="AttributeDefinition">
     <property name="name" value="name" />
@@ -192,7 +174,6 @@
               <bean p:propertyName="proposalPersonNumber" parent="Uif-DataField"/>
               <bean p:propertyName="proposalNumber" parent="Uif-DataField"/>
               <bean p:propertyName="biographyNumber" parent="Uif-DataField"/>
-              <bean p:propertyName="data" parent="Uif-DataField"/>
               <bean p:propertyName="name" parent="Uif-DataField"/>
             </list>
           </property>
@@ -213,7 +194,6 @@
         <bean parent="FieldDefinition" p:attributeName="proposalPersonNumber"/>
         <bean parent="FieldDefinition" p:attributeName="biographyNumber"/>
         <bean parent="FieldDefinition" p:attributeName="proposalNumber"/>
-        <bean parent="FieldDefinition" p:attributeName="data"/>
         <bean parent="FieldDefinition" p:attributeName="name"/>
       </list>
     </property>
@@ -222,7 +202,6 @@
         <bean parent="FieldDefinition" p:attributeName="proposalPersonNumber" p:forceInquiry="true"/>
         <bean parent="FieldDefinition" p:attributeName="biographyNumber" p:forceInquiry="true"/>
         <bean parent="FieldDefinition" p:attributeName="proposalNumber" p:forceInquiry="true"/>
-        <bean parent="FieldDefinition" p:attributeName="data"/>
         <bean parent="FieldDefinition" p:attributeName="name"/>
       </list>
     </property>
@@ -236,7 +215,6 @@
         <bean p:propertyName="proposalPersonNumber" parent="Uif-LookupCriteriaInputField"/>
         <bean p:propertyName="biographyNumber" parent="Uif-LookupCriteriaInputField"/>
         <bean p:propertyName="proposalNumber" parent="Uif-LookupCriteriaInputField"/>
-        <bean p:propertyName="data" parent="Uif-LookupCriteriaInputField"/>
         <bean p:propertyName="name" parent="Uif-LookupCriteriaInputField"/>
       </list>
     </property>


### PR DESCRIPTION
Using WeakReference to make GC more aggressive and avoiding KRAD validation from pulling down attachment data on every save.