### PR TITLE
RESKC-195:Fix spring profile usage for int tests

### DIFF
--- a/coeus-impl/pom.xml
+++ b/coeus-impl/pom.xml
@@ -59,6 +59,20 @@
     </properties>
 
     <build>
+		<resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>false</filtering>
+            </resource>
+            <resource>
+                <filtering>true</filtering>
+                <directory>src/main/resources</directory>
+                <includes>
+                    <include>META-INF/coeus-impl-build.properties</include>
+                </includes>
+            </resource>
+        </resources>
+    	
         <plugins>
             <plugin>
                 <groupId>org.apache.cxf</groupId>

--- a/coeus-impl/src/main/java/org/kuali/coeus/sys/framework/service/KcServiceLocatorListener.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/sys/framework/service/KcServiceLocatorListener.java
@@ -18,8 +18,14 @@
  */
 package org.kuali.coeus.sys.framework.service;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.Properties;
+
 import org.kuali.rice.core.web.listener.KualiInitializeListener;
 
+import javax.servlet.ServletContext;
 import javax.servlet.ServletContextEvent;
 
 public class KcServiceLocatorListener extends KualiInitializeListener {
@@ -31,6 +37,27 @@ public class KcServiceLocatorListener extends KualiInitializeListener {
         LOG.debug("Starting KcServiceLocatorListener");
         super.contextInitialized(sce);
         KcServiceLocator.setAppContext(getContext());
+    }
+    
+    /**
+     * Translates context parameters from the web.xml into entries in a Properties file.
+     */
+    protected Properties getContextParameters(ServletContext context) {
+        Properties properties = super.getContextParameters(context);
+        Properties buildProps = new Properties();
+        try (InputStream is = getClass().getClassLoader().getResourceAsStream("META-INF/coeus-impl-build.properties")) {
+        	buildProps.load(is);
+        	for (Map.Entry<Object, Object> prop : buildProps.entrySet()) {
+        		context.setInitParameter(prop.getKey().toString(), prop.getValue().toString());
+        	}
+        	properties.putAll(buildProps);
+        } catch (IOException e) {
+        	throw new RuntimeException("Unable to read build properties", e);
+        }
+        
+
+        
+        return properties;
     }
 
 }

--- a/coeus-impl/src/main/resources/META-INF/coeus-impl-build.properties
+++ b/coeus-impl/src/main/resources/META-INF/coeus-impl-build.properties
@@ -1,0 +1,1 @@
+spring.profiles.active=${build.spring.profiles.active}

--- a/coeus-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/coeus-webapp/src/main/webapp/WEB-INF/web.xml
@@ -36,12 +36,6 @@
         <param-value>classpath:KcBootstrapSpringBeans.xml</param-value>
     </context-param>
 
-    <!-- this is resource filtered by the maven build to enable spring profiles -->
-    <context-param>
-        <param-name>spring.profiles.active</param-name>
-        <param-value>${build.spring.profiles.active}</param-value>
-    </context-param>
-
     <filter>
         <filter-name>HttpRequestLogger</filter-name>
         <filter-class>org.kuali.rice.core.RequestLoggingFilter</filter-class>


### PR DESCRIPTION
Spring profiles break under int tests because the web.xml file isn't filtered. And when the web.xml contains the context param it overrides any other attempt to set it during the Jetty startup for integration tests. This moves that parameter from the web.xml to a new coeus-impl-build.properties file that is read in by the context listener.