### PR TITLE
KRACOEUS-8839:Manage attachment deletion through references

### DIFF
--- a/coeus-db/coeus-db-sql/src/main/resources/co/kuali/coeus/data/migration/sql/mysql/kc/bootstrap/V601_027__KRACOEUS-8839.sql
+++ b/coeus-db/coeus-db-sql/src/main/resources/co/kuali/coeus/data/migration/sql/mysql/kc/bootstrap/V601_027__KRACOEUS-8839.sql
@@ -1,0 +1,6 @@
+alter table narrative_attachment 
+	add foreign key narrative_attachment_fk1 (file_data_id) references file_data (id);
+
+alter table eps_prop_person_bio_attachment 
+	add foreign key eps_prop_person_bio_attach_fk1 (file_data_id) references file_data (id);
+	

--- a/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/attachment/Narrative.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/attachment/Narrative.java
@@ -747,7 +747,7 @@ public class Narrative extends KcPersistableBusinessObjectBase implements Hierar
         this.kcAttachmentService = kcAttachmentService;
     }
 
-    @PreRemove
+    @PostRemove
     public void removeData() {
         if (getNarrativeAttachment().getFileDataId() != null) {
             getKcAttachmentDao().removeData(getNarrativeAttachment().getFileDataId());

--- a/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/person/attachment/ProposalPersonBiography.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/person/attachment/ProposalPersonBiography.java
@@ -508,7 +508,7 @@ public class ProposalPersonBiography extends KcPersistableBusinessObjectBase imp
         this.kcAttachmentService = kcAttachmentService;
     }
 
-    @PreRemove
+    @PostRemove
     public void removeData() {
         if (getPersonnelAttachment().getFileDataId() != null) {
             getKcAttachmentDao().removeData(getPersonnelAttachment().getFileDataId());


### PR DESCRIPTION
Please do not merge this. This is simply to get comment and start discussion on if this is a good direction.

In order to avoid copying attachment data, this is an attempt to do attachment deletion through references and only delete attachment data when there are no references to the attachment.
This does have some problems though as this implementation is fairly Mysql specific and assumes access to information_schema. We can build something similar for Oracle using all_constraints, but that hasn't been done yet. Additionally it appears that our version of XAPool wasn't built for Java 7 as getSchema method is unavailable.