### PR TITLE
RESKC-8:dismiss add person modal on add person request

### DIFF
--- a/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/person/ProposalDevelopmentPersonnelController.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/propdev/impl/person/ProposalDevelopmentPersonnelController.java
@@ -32,6 +32,7 @@ import org.kuali.coeus.propdev.impl.notification.ProposalDevelopmentNotification
 import org.kuali.coeus.propdev.impl.person.attachment.ProposalPersonBiography;
 import org.kuali.coeus.common.framework.person.PersonTypeConstants;
 import org.kuali.kra.infrastructure.KeyConstants;
+import org.kuali.rice.krad.uif.UifConstants;
 import org.kuali.rice.krad.uif.UifParameters;
 import org.kuali.rice.krad.uif.util.ObjectPropertyUtils;
 import org.kuali.rice.krad.web.controller.MethodAccessible;
@@ -136,6 +137,7 @@ public class ProposalDevelopmentPersonnelController extends ProposalDevelopmentC
        }
        getKeyPersonnelService().addProposalPerson(newProposalPerson, form.getProposalDevelopmentDocument());
        form.getAddKeyPersonHelper().reset();
+       form.setAjaxReturnType(UifConstants.AjaxReturnTypes.UPDATEPAGE.getKey());
        return getRefreshControllerService().refresh(form);
    }
 

--- a/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/person/ProposalPersonnelPage.xml
+++ b/coeus-impl/src/main/resources/org/kuali/coeus/propdev/impl/person/ProposalPersonnelPage.xml
@@ -259,8 +259,8 @@
 
                         <bean parent="PropDev-PersonnelPage-WizardButton-Continue"
                               p:actionParameters="PropDev-PersonnelPage-Wizard.step:2"
-                              p:actionLabel="Add Person" p:ajaxSubmit="false"
-                              p:methodToCall="addPerson" p:successCallback="dismissDialog('PropDev-PersonnelPage-Wizard');"
+                              p:actionLabel="Add Person"
+                              p:methodToCall="addPerson" p:dialogDismissOption="REQUEST"
                               p:order="10" />
                         <bean parent="PropDev-PersonnelPage-WizardButton-Back"
                               p:actionParameters="PropDev-PersonnelPage-Wizard.step:1" p:order="20" />


### PR DESCRIPTION
fixes issue where the modal would still display after add person request, and could be pressed multiple times.