### PR TITLE
RESKC-244:fix STE on award budget navigation

### DIFF
--- a/coeus-impl/src/main/java/org/kuali/coeus/common/budget/framework/personnel/BudgetPersonnelDetails.java
+++ b/coeus-impl/src/main/java/org/kuali/coeus/common/budget/framework/personnel/BudgetPersonnelDetails.java
@@ -647,7 +647,10 @@ public class BudgetPersonnelDetails extends BudgetLineItemBase implements Budget
     @Deprecated
     @Override
     public CostElement getCostElementBO() {
-        return getBudgetLineItem().getCostElementBO();
+        if (getBudgetLineItem() != null) {
+            return getBudgetLineItem().getCostElementBO();
+        }
+        return costElementBO;
     }
 
     @Deprecated
@@ -723,7 +726,7 @@ public class BudgetPersonnelDetails extends BudgetLineItemBase implements Budget
 
 	@Override
 	public Long getBudgetLineItemId() {
-		return getBudgetLineItem().getBudgetLineItemId();
+		return budgetLineItemId;
 	}
 
 	public BudgetPeriodType getBudgetPeriodType() {


### PR DESCRIPTION
for pd budget we made a change to get the costElementBo from the the budgetLineItem, however, in award budget (still using OJB) the budgetLineItem is not fetched and results in NPE