### PR TITLE
RESOPS-42:Fix GRM SQL Error

### DIFF
--- a/coeus-db/coeus-db-sql/src/main/resources/co/kuali/coeus/data/migration/sql/mysql/grm/V600_082__RESOLVE_COMM_SCHEDULE_ATTACHMENT_ID.sql
+++ b/coeus-db/coeus-db-sql/src/main/resources/co/kuali/coeus/data/migration/sql/mysql/grm/V600_082__RESOLVE_COMM_SCHEDULE_ATTACHMENT_ID.sql
@@ -25,12 +25,17 @@ drop procedure if exists resolveMultipleSequenceTables
 create procedure resolveMultipleSequenceTables() 
 begin
 declare seqExists int default 0;
+declare records int default 0;
 select count(*) into seqExists from information_schema.tables where table_schema = DATABASE() and table_name = 'COMM_SCHEDULE_ATTACHMENT_ID';
-	
+
 if (seqExists > 0) then
+select count(*) into records from COMM_SCHEDULE_ATTACHMENT_ID;
+if (records > 0) then
 select max(id)+1 into @newMax from COMM_SCHEDULE_ATTACHMENT_ID;
-prepare stmt from 'alter table SEQ_COMM_SCHED_ATTACH_ID AUTO_INCREMENT = ?';
-execute stmt using @newMax;
+select concat('alter table SEQ_COMM_SCHED_ATTACH_ID AUTO_INCREMENT = ', @newMax) into @fixStmt from dual;
+prepare stmt from @fixStmt;
+execute stmt;
+end if;
 end if;
 
 end


### PR DESCRIPTION
The following will need to be run on all existing up-to-date schemas
`update schema_version set checksum = -1680816690 where version = '600.082';`